### PR TITLE
Slice 3 — Civic Brief generation + admin approval flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,10 +11,20 @@ SUPABASE_URL=
 SUPABASE_SERVICE_ROLE_KEY=
 
 # --- Hub config ---
-# Public URL the hub advertises in events and the discovery manifest.
+# Public URL the hub advertises as its API origin in events (source.hub_url)
+# and the discovery manifest.
 # Local dev: http://localhost:3000
 # Production: https://floyd.civic.social  (or whatever your domain is)
 BASE_URL=http://localhost:3000
+
+# Public URL the hub uses when constructing user-facing action_url values
+# on emitted events (per Civic Event Spec §3 — "link to take action").
+# Falls back to BASE_URL if unset, which is correct for single-origin
+# deployments where the UI and API share a hostname (e.g. Vercel). In
+# split-origin local dev (API on :3000, UI on :5173) set this to the UI
+# origin so feed posts navigate to the UI, not the JSON API.
+# Local split-origin dev: http://localhost:5173
+CIVIC_UI_BASE_URL=
 
 # Port for the local dev server (defaults to 3000 if unset).
 PORT=3000
@@ -55,3 +65,21 @@ CIVIC_ALLOW_SEED=true
 # for local dev and preview to skip real email delivery. MUST be unset
 # in Production so real verification is enforced.
 CIVIC_DEMO_BYPASS_CODE=000000
+
+# --- SMTP (Civic Brief delivery) ---
+# When all five SMTP_* vars below are set, admin approval of a Civic Brief
+# delivers the formatted brief to BOARD_RECIPIENT_EMAIL via nodemailer.
+# When any of them are unset, email delivery falls back to console logging
+# (visible in the server logs) and the approval flow treats delivery as
+# successful. This keeps local dev runnable without SMTP credentials.
+# SMTP_PORT 465 uses TLS; 587 uses STARTTLS.
+SMTP_HOST=
+SMTP_PORT=
+SMTP_USER=
+SMTP_PASS=
+SMTP_FROM=
+
+# Single email address to receive Civic Briefs on approval. Comma-separated
+# multi-recipient is supported and parsed by the server. If unset, admin
+# approval returns 503 with an actionable error.
+BOARD_RECIPIENT_EMAIL=

--- a/.env.example
+++ b/.env.example
@@ -79,7 +79,10 @@ SMTP_USER=
 SMTP_PASS=
 SMTP_FROM=
 
-# Single email address to receive Civic Briefs on approval. Comma-separated
-# multi-recipient is supported and parsed by the server. If unset, admin
-# approval returns 503 with an actionable error.
+# Fallback recipient list for Civic Brief delivery. Comma-separated
+# multi-recipient supported. As of Slice 3 addendum, the admin UI has a
+# "Delivery settings" panel under /admin/briefs that writes to the
+# hub_settings table. The backend reads the DB setting first and falls
+# back to this env var only if no DB row exists, so once an admin saves
+# recipients in the UI this env var is effectively ignored.
 BOARD_RECIPIENT_EMAIL=

--- a/IDEAS.md
+++ b/IDEAS.md
@@ -68,15 +68,18 @@ code. Ideas for process plugins worth exploring:
 
 ## Backend / Spec alignment
 
-- Emit `action_url` as the UI-facing URL, not the API origin. Currently the
-  feed has a client-side workaround; fixing at the source is cleaner and
-  critical for federation.
 - Carry the process title in `civic.process.result_published` event data, so
-  federated consumers can render "Results available: [title]" without
-  calling back to the origin hub.
+  federated consumers can render result posts without calling back to the
+  origin hub. Briefs already carry it; votes still don't.
 - Theme consolidation — migrate legacy `--text-color` / `--primary-color`
   vars in `ui/src/index.css` to the semantic tokens in
   `ui/src/styles/theme.css`.
+- Slice 3.5: populate `BriefContent.comments` from the `civic.input`
+  stream at brief generation time. Today the array is empty until admin
+  manually enters entries during review. The generator in
+  `civic-hub/src/modules/civic.brief/service.ts` (`generateBriefContent`)
+  should accept the list of community-input bodies and seed
+  `content.comments` with sanitized entries so the admin review starts warm.
 
 ## Governance / Community
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,9 @@
       "license": "MIT",
       "dependencies": {
         "@supabase/supabase-js": "^2.103.3",
-        "express": "^4.21.0"
+        "@types/nodemailer": "^8.0.0",
+        "express": "^4.21.0",
+        "nodemailer": "^8.0.5"
       },
       "devDependencies": {
         "@types/express": "^5.0.0",
@@ -19,7 +21,7 @@
         "typescript": "^5.6.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": "20.x"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -610,6 +612,15 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-8.0.0.tgz",
+      "integrity": "sha512-fyf8jWULsCo0d0BuoQ75i6IeoHs47qcqxWc7yUdUcV0pOZGjUTTOvwdG1PRXUDqN/8A64yQdQdnA2pZgcdi+cA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/qs": {
@@ -1247,6 +1258,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.5.tgz",
+      "integrity": "sha512-0PF8Yb1yZuQfQbq+5/pZJrtF6WQcjTd5/S4JOHs9PGFxuTqoB/icwuB44pOdURHJbRKX1PPoJZtY7R4VUoCC8w==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/object-inspect": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
   "license": "MIT",
   "dependencies": {
     "@supabase/supabase-js": "^2.103.3",
-    "express": "^4.21.0"
+    "@types/nodemailer": "^8.0.0",
+    "express": "^4.21.0",
+    "nodemailer": "^8.0.5"
   },
   "devDependencies": {
     "@types/express": "^5.0.0",

--- a/scripts/testBriefFlow.ts
+++ b/scripts/testBriefFlow.ts
@@ -1,0 +1,301 @@
+/**
+ * Test flow script — validates the Civic Brief lifecycle end-to-end:
+ *   1. Auth as an admin user via the demo bypass code
+ *   2. Create a civic.vote process
+ *   3. Activate the vote
+ *   4. Submit a few votes (as different actors — need fresh sessions)
+ *   5. Close the vote (which should spawn a civic.brief)
+ *   6. Verify aggregation_completed fires and the brief appears
+ *   7. PATCH the brief with some comments
+ *   8. Approve the brief (delivers email, emits outcome_recorded,
+ *      result_published for brief + vote, transitions both to finalized)
+ *   9. Verify:
+ *      - vote status is finalized
+ *      - brief is published at GET /brief/:id
+ *      - /events has the full expected sequence
+ *      - /process public list includes the brief (since it's now published)
+ *      - GET /process/:voteId/state shows follow_up_process_ids pointing
+ *        at the brief
+ *
+ * Prerequisites:
+ *   - Hub dev server running on localhost:3000.
+ *   - .env includes:
+ *       CIVIC_ADMIN_EMAILS=<your admin email>
+ *       CIVIC_DEMO_BYPASS_CODE=000000  (or any code)
+ *       BOARD_RECIPIENT_EMAIL=board@example.test
+ *     (SMTP vars can stay unset — delivery will console-log.)
+ *
+ * Run: BASE_URL=http://localhost:3000 ADMIN_EMAIL=you@example.com \
+ *      BYPASS_CODE=000000 npx tsx scripts/testBriefFlow.ts
+ */
+
+const BASE = process.env.BASE_URL ?? "http://localhost:3000";
+const ADMIN_EMAIL = process.env.ADMIN_EMAIL;
+const BYPASS_CODE = process.env.BYPASS_CODE ?? "000000";
+
+if (!ADMIN_EMAIL) {
+  console.error("Set ADMIN_EMAIL env var (must match CIVIC_ADMIN_EMAILS).");
+  process.exit(1);
+}
+
+interface HttpResult<T = unknown> {
+  status: number;
+  data: T;
+}
+
+async function request<T = unknown>(
+  method: string,
+  path: string,
+  body?: unknown,
+  token?: string,
+): Promise<HttpResult<T>> {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (token) headers["Authorization"] = `Bearer ${token}`;
+  const res = await fetch(`${BASE}${path}`, {
+    method,
+    headers,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const data = (await res.json().catch(() => ({}))) as T;
+  return { status: res.status, data };
+}
+
+function step(label: string): void {
+  console.log(`\n━━━ ${label} ━━━`);
+}
+
+function ok(msg: string): void {
+  console.log(`  ✓ ${msg}`);
+}
+
+function fail(msg: string, detail?: unknown): never {
+  console.error(`  ✗ ${msg}`);
+  if (detail) console.error("    detail:", JSON.stringify(detail, null, 2));
+  process.exit(1);
+}
+
+function assert(cond: boolean, msg: string, detail?: unknown): void {
+  if (!cond) fail(msg, detail);
+  ok(msg);
+}
+
+async function authAs(email: string): Promise<{ token: string; userId: string }> {
+  const req = await request<{ message?: string }>("POST", "/auth/request-code", { email });
+  if (req.status !== 200) fail(`request-code failed: ${req.status}`, req.data);
+  const verify = await request<{ token?: string; user?: { id: string; is_resident: boolean } }>(
+    "POST",
+    "/auth/verify",
+    { email, code: BYPASS_CODE },
+  );
+  if (verify.status !== 200 || !verify.data.token || !verify.data.user) {
+    fail(`verify failed: ${verify.status}`, verify.data);
+  }
+  const token = verify.data.token!;
+  const user = verify.data.user!;
+  // Affirm residency so we can participate.
+  if (!user.is_resident) {
+    const aff = await request("POST", "/auth/residency", { affirm: true }, token);
+    if (aff.status !== 200) fail(`residency failed: ${aff.status}`, aff.data);
+  }
+  return { token, userId: user.id };
+}
+
+async function run(): Promise<void> {
+  console.log(`🏛️  Civic Brief Flow Test\n  Target: ${BASE}\n  Admin:  ${ADMIN_EMAIL}`);
+
+  // 1. Health
+  step("1. Health");
+  const h = await request("GET", "/health");
+  assert(h.status === 200, "Health responds 200");
+
+  // 2. Admin auth
+  step("2. Auth as admin");
+  const admin = await authAs(ADMIN_EMAIL as string);
+  ok(`Got admin session for ${(admin.userId ?? "").slice(0, 12)}…`);
+
+  // 3. Create a vote
+  step("3. Create civic.vote process");
+  const createRes = await request<{ id: string; status: string }>(
+    "POST",
+    "/process",
+    {
+      definition: { type: "civic.vote", version: "0.1" },
+      title: "Test: add a downtown crosswalk",
+      description: "Should the county add a signalized crosswalk at Main & 2nd?",
+      jurisdiction: "us-va-floyd",
+      createdBy: admin.userId,
+      state: { options: ["yes", "no"] },
+    },
+    admin.token,
+  );
+  assert(createRes.status === 201 || createRes.status === 200, "Create vote succeeds", createRes);
+  const voteId = createRes.data.id;
+  ok(`Vote ID: ${voteId}`);
+
+  // 4. Activate
+  step("4. Activate vote");
+  const act = await request(
+    "POST",
+    `/process/${voteId}/action`,
+    { type: "process.activate", actor: admin.userId, payload: {} },
+    admin.token,
+  );
+  assert(act.status === 200, "Activate succeeds", act);
+
+  // 5. Submit a vote (admin votes for "yes"). Just one is enough to prove the
+  //    flow; scripting multi-user auth here is more trouble than it's worth.
+  step("5. Submit a vote");
+  const v1 = await request(
+    "POST",
+    `/process/${voteId}/action`,
+    { type: "process.vote", actor: admin.userId, payload: { option: "yes" } },
+    admin.token,
+  );
+  assert(v1.status === 200, "Vote submitted", v1);
+
+  // 6. Close — should auto-spawn a brief
+  step("6. Close vote (spawns brief)");
+  const close = await request<{ tally: Record<string, number>; total_votes: number; brief_process_id?: string }>(
+    "POST",
+    `/process/${voteId}/action`,
+    { type: "process.close", actor: admin.userId, payload: {} },
+    admin.token,
+  );
+  assert(close.status === 200, "Close succeeds", close);
+  assert(close.data.total_votes === 1, "Tally has 1 vote");
+  const briefId = close.data.brief_process_id;
+  assert(typeof briefId === "string", "Close response includes brief_process_id");
+  ok(`Brief ID: ${briefId}`);
+
+  // 7. Check events — look for the new spec events
+  step("7. Verify spec-compliant event sequence");
+  const evs = await request<{ events: Array<{ event_type: string; process_id: string; data: unknown }> }>(
+    "GET",
+    "/events",
+  );
+  const voteEvents = evs.data.events.filter((e) => e.process_id === voteId);
+  const briefEvents = evs.data.events.filter((e) => e.process_id === briefId);
+  const voteTypes = voteEvents.map((e) => e.event_type);
+  const briefTypes = briefEvents.map((e) => e.event_type);
+  console.log("  vote events:", voteTypes.join(", "));
+  console.log("  brief events:", briefTypes.join(", "));
+  assert(voteTypes.includes("civic.process.ended"), "Vote emitted .ended");
+  assert(voteTypes.includes("civic.process.aggregation_completed"), "Vote emitted .aggregation_completed (NEW)");
+  assert(briefTypes.includes("civic.process.created"), "Brief emitted .created");
+  assert(briefTypes.includes("civic.process.aggregation_completed"), "Brief emitted .aggregation_completed");
+  assert(!voteTypes.includes("civic.process.result_published"), "Vote has NOT published yet (brief-gated)");
+
+  // 8. Vote should link to brief via follow_up_process_ids
+  step("8. Vote's follow_up_process_ids points at brief");
+  const voteState = await request<{ follow_up_process_ids?: string[] }>(
+    "GET",
+    `/process/${voteId}/state`,
+  );
+  // follow_up_process_ids lives on the raw state, not necessarily in the read model.
+  // Falling back to fetching the bare process:
+  const rawVote = await request<{ state: { follow_up_process_ids?: string[] } }>(
+    "GET",
+    `/process/${voteId}`,
+  );
+  const followUps = rawVote.data.state?.follow_up_process_ids ?? [];
+  assert(followUps.includes(briefId as string), "follow_up_process_ids includes brief ID");
+
+  // 9. Brief isn't public yet
+  step("9. Brief invisible to public before approval");
+  const preBrief = await request("GET", `/brief/${briefId}`);
+  assert(preBrief.status === 404, "GET /brief/:id → 404 while pending");
+
+  // 10. PATCH the brief with comments
+  step("10. PATCH brief with admin edits");
+  const patched = await request<{ content: { comments: string[]; admin_notes: string } }>(
+    "PATCH",
+    `/admin/briefs/${briefId}`,
+    {
+      comments: ["Support from most residents.", "A few concerns about funding."],
+      admin_notes: "The Board should consider a phased rollout.",
+    },
+    admin.token,
+  );
+  assert(patched.status === 200, "PATCH succeeds", patched);
+  assert(patched.data.content.comments.length === 2, "Comments were saved");
+  assert(
+    patched.data.content.admin_notes.includes("phased rollout"),
+    "Admin notes saved",
+  );
+
+  // 11. Approve the brief
+  step("11. Approve brief (email + orchestration)");
+  const approve = await request<{ brief: { publication_status: string; delivered_to: string[] } }>(
+    "POST",
+    `/admin/briefs/${briefId}/approve`,
+    {},
+    admin.token,
+  );
+  if (approve.status === 503) {
+    console.log("  ⚠ 503 — BOARD_RECIPIENT_EMAIL is not set on the server.");
+    console.log("  Set it in .env and restart the hub, then re-run this script.");
+    process.exit(1);
+  }
+  assert(approve.status === 200, "Approve succeeds", approve);
+  assert(approve.data.brief.publication_status === "published", "Brief is published");
+  assert(approve.data.brief.delivered_to.length > 0, "Brief has recipients");
+
+  // 12. Brief is now public
+  step("12. Public /brief/:id renders");
+  const pubBrief = await request<{ title: string; comments: string[] }>(
+    "GET",
+    `/brief/${briefId}`,
+  );
+  assert(pubBrief.status === 200, "GET /brief/:id → 200 after approval");
+  assert(pubBrief.data.comments.length === 2, "Public brief has the admin's comments");
+
+  // 13. Final event sequence — brief + vote result_published both fired
+  step("13. Final event sequence");
+  const finalEvs = await request<{ events: Array<{ event_type: string; process_id: string }> }>(
+    "GET",
+    "/events",
+  );
+  const finalVoteTypes = finalEvs.data.events
+    .filter((e) => e.process_id === voteId)
+    .map((e) => e.event_type);
+  const finalBriefTypes = finalEvs.data.events
+    .filter((e) => e.process_id === briefId)
+    .map((e) => e.event_type);
+  assert(
+    finalBriefTypes.includes("civic.process.outcome_recorded"),
+    "Brief emitted .outcome_recorded",
+  );
+  assert(
+    finalBriefTypes.includes("civic.process.result_published"),
+    "Brief emitted .result_published",
+  );
+  assert(
+    finalVoteTypes.includes("civic.process.result_published"),
+    "Vote emitted .result_published (via brief-gated finalize)",
+  );
+
+  // 14. Vote finalized
+  step("14. Vote is finalized");
+  const finalVote = await request<{ status: string }>("GET", `/process/${voteId}`);
+  assert(finalVote.data.status === "finalized", "Vote status is finalized");
+
+  // 15. Public process list now includes the brief (published only)
+  step("15. Public list includes the published brief");
+  const list = await request<Array<{ id: string; type: string; publication_status?: string }>>(
+    "GET",
+    "/process",
+  );
+  const listedBrief = list.data.find((p) => p.id === briefId);
+  assert(listedBrief !== undefined, "Brief is in the public list");
+  assert(
+    listedBrief?.publication_status === "published",
+    "Listed brief is marked published",
+  );
+
+  console.log("\n🎉 All assertions passed.\n");
+}
+
+run().catch((err) => {
+  console.error("\n💥 Unhandled error:", err);
+  process.exit(1);
+});

--- a/scripts/testBriefFlow.ts
+++ b/scripts/testBriefFlow.ts
@@ -155,16 +155,16 @@ async function run(): Promise<void> {
 
   // 6. Close — should auto-spawn a brief
   step("6. Close vote (spawns brief)");
-  const close = await request<{ tally: Record<string, number>; total_votes: number; brief_process_id?: string }>(
+  const close = await request<{ result: { tally: Record<string, number>; total_votes: number; brief_process_id?: string } }>(
     "POST",
     `/process/${voteId}/action`,
     { type: "process.close", actor: admin.userId, payload: {} },
     admin.token,
   );
   assert(close.status === 200, "Close succeeds", close);
-  assert(close.data.total_votes === 1, "Tally has 1 vote");
-  const briefId = close.data.brief_process_id;
-  assert(typeof briefId === "string", "Close response includes brief_process_id");
+  assert(close.data.result?.total_votes === 1, "Tally has 1 vote", close.data);
+  const briefId = close.data.result?.brief_process_id;
+  assert(typeof briefId === "string", "Close response includes brief_process_id", close.data);
   ok(`Brief ID: ${briefId}`);
 
   // 7. Check events — look for the new spec events

--- a/src/app.ts
+++ b/src/app.ts
@@ -48,7 +48,7 @@ app.use((req, res, next) => {
     res.header("Vary", "Origin");
   }
   res.header("Access-Control-Allow-Headers", "Content-Type, Authorization");
-  res.header("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+  res.header("Access-Control-Allow-Methods", "GET, POST, PATCH, OPTIONS");
   if (req.method === "OPTIONS") {
     res.sendStatus(204);
     return;

--- a/src/app.ts
+++ b/src/app.ts
@@ -14,6 +14,7 @@ import proposalRoutes from "./routes/proposalRoutes.js";
 import adminRoutes from "./routes/adminRoutes.js";
 import authRoutes from "./routes/authRoutes.js";
 import voteLogRoutes from "./routes/voteLogRoutes.js";
+import briefRoutes from "./routes/briefRoutes.js";
 import { ensureSeeded } from "./debug/autoSeed.js";
 import { pingDb } from "./db/client.js";
 
@@ -77,6 +78,9 @@ app.use("/admin", adminRoutes);
 // Vote log and receipt verification
 app.use("/votes", voteLogRoutes);
 
+// Civic Briefs — public read of published briefs
+app.use("/brief", briefRoutes);
+
 // --- Primary public interfaces ---
 // Events are the PRIMARY public interface of the hub.
 // All external systems (feeds, dashboards, federation) should rely on events.
@@ -117,6 +121,11 @@ app.get("/", (_req, res) => {
       "POST /auth/logout": "Destroy session",
       "GET /votes/:id/log": "Public vote audit log (available after vote closes)",
       "GET /votes/:id/verify?receipt=X": "Verify a vote receipt",
+      "GET /admin/briefs": "List civic briefs for admin review (optional ?status=)",
+      "GET /admin/briefs/:id": "Get full brief detail for admin",
+      "PATCH /admin/briefs/:id": "Edit brief concerns/suggestions/notes (pending only)",
+      "POST /admin/briefs/:id/approve": "Approve brief: email + publish",
+      "GET /brief/:id": "Public read of a published civic brief",
       "GET /events": "List all events (primary public interface)",
       "GET /events?process_id=X": "Filter events by process",
       "GET /events?type=X": "Filter events by type (e.g., civic.process.vote_submitted)",

--- a/src/controllers/adminBriefController.ts
+++ b/src/controllers/adminBriefController.ts
@@ -1,0 +1,281 @@
+// Admin brief controller — list, read, edit, and approve civic.brief
+// processes.
+//
+// The approve handler orchestrates the full publication sequence:
+//   1. edit check (status must be "pending")
+//   2. mark "approved", set approved_at
+//   3. deliver email (HALT on failure — later steps won't run)
+//   4. record delivered_to
+//   5. emit civic.process.outcome_recorded
+//   6. mark "published", set published_at
+//   7. emit civic.process.result_published (brief)
+//   8. finalize the linked vote (civic.vote.finalizeVote), which emits
+//      civic.process.result_published for the vote
+//
+// Mutations to in-memory state are persisted via saveProcessState only on
+// success. Durable event emissions that happen mid-sequence are not
+// rolled back on failure — this matches the existing hub architecture
+// (events are the source of truth) and is an accepted pilot-phase
+// limitation for the same reason as the executeAction race condition.
+
+import { Request, Response } from "express";
+import { emitEvent } from "../events/eventEmitter.js";
+import {
+  approveBrief,
+  editBrief,
+  getAdminReadModel,
+  getAdminSummary,
+  type BriefContentPatch,
+  type BriefProcessState,
+  type BriefPublicationStatus,
+} from "../modules/civic.brief/index.js";
+import {
+  finalizeVote,
+  type VoteProcessState,
+} from "../modules/civic.vote/index.js";
+import {
+  getAllProcesses,
+  getProcess,
+  saveProcessState,
+} from "../services/processService.js";
+import { getAuthUser } from "../middleware/auth.js";
+import { sendEmail, parseRecipients } from "../services/mailer.js";
+import { uiBaseUrl } from "../utils/baseUrl.js";
+
+const HUB_LABEL = "Floyd Civic Hub";
+
+function briefState(record: { state: Record<string, unknown> }): BriefProcessState {
+  return record.state as unknown as BriefProcessState;
+}
+
+function voteState(record: { state: Record<string, unknown> }): VoteProcessState {
+  return record.state as unknown as VoteProcessState;
+}
+
+function publicBriefUrl(briefId: string): string {
+  return `${uiBaseUrl()}/brief/${briefId}`;
+}
+
+function isBriefPublicationStatus(s: string): s is BriefPublicationStatus {
+  return s === "pending" || s === "approved" || s === "published";
+}
+
+/**
+ * GET /admin/briefs — list briefs with optional ?status= filter.
+ * Returns pending first (needing review), then approved, then published.
+ */
+export async function handleAdminListBriefs(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  try {
+    const statusFilter = req.query.status as string | undefined;
+    const all = await getAllProcesses();
+    const briefs = all.filter((p) => p.definition.type === "civic.brief");
+
+    const summaries = briefs.map((p) => ({
+      ...getAdminSummary(briefState(p), {
+        id: p.id,
+        title: p.title,
+        createdAt: p.createdAt,
+      }),
+    }));
+
+    const filtered = statusFilter && isBriefPublicationStatus(statusFilter)
+      ? summaries.filter((b) => b.publication_status === statusFilter)
+      : summaries;
+
+    // Sort: pending first, then approved, then published. Within each bucket,
+    // newest generated first.
+    const rank: Record<string, number> = { pending: 0, approved: 1, published: 2 };
+    filtered.sort((a, b) => {
+      const statusA = (a.publication_status as string) ?? "";
+      const statusB = (b.publication_status as string) ?? "";
+      const r = (rank[statusA] ?? 99) - (rank[statusB] ?? 99);
+      if (r !== 0) return r;
+      const ga = (a.generated_at as string) ?? "";
+      const gb = (b.generated_at as string) ?? "";
+      return gb.localeCompare(ga);
+    });
+
+    res.json(filtered);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    res.status(500).json({ error: message });
+  }
+}
+
+/**
+ * GET /admin/briefs/:id — full brief detail for admin review.
+ */
+export async function handleAdminGetBrief(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  try {
+    const id = req.params.id as string;
+    const briefRecord = await getProcess(id);
+    if (!briefRecord || briefRecord.definition.type !== "civic.brief") {
+      res.status(404).json({ error: "Brief not found" });
+      return;
+    }
+    const model = getAdminReadModel(briefState(briefRecord), {
+      id: briefRecord.id,
+      title: briefRecord.title,
+      createdAt: briefRecord.createdAt,
+      createdBy: briefRecord.createdBy,
+    });
+    res.json(model);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    res.status(500).json({ error: message });
+  }
+}
+
+/**
+ * PATCH /admin/briefs/:id — edit concerns, suggestions, and admin_notes.
+ * Rejects with 409 if the brief is no longer in pending status.
+ */
+export async function handlePatchBrief(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  try {
+    const id = req.params.id as string;
+    const briefRecord = await getProcess(id);
+    if (!briefRecord || briefRecord.definition.type !== "civic.brief") {
+      res.status(404).json({ error: "Brief not found" });
+      return;
+    }
+    const state = briefState(briefRecord);
+    if (state.publication_status !== "pending") {
+      res.status(409).json({
+        error: `Cannot edit brief: publication_status is "${state.publication_status}".`,
+      });
+      return;
+    }
+
+    const body = req.body ?? {};
+    const patch: BriefContentPatch = {};
+    if (Array.isArray(body.comments)) patch.comments = body.comments;
+    if (typeof body.admin_notes === "string") patch.admin_notes = body.admin_notes;
+
+    const actor = getAuthUser(res).id;
+    const ctx = {
+      process_id: briefRecord.id,
+      hub_id: briefRecord.hubId,
+      jurisdiction: briefRecord.jurisdiction,
+      emit: emitEvent,
+    };
+
+    await editBrief(state, actor, patch, ctx);
+    await saveProcessState(briefRecord);
+
+    const model = getAdminReadModel(state, {
+      id: briefRecord.id,
+      title: briefRecord.title,
+      createdAt: briefRecord.createdAt,
+      createdBy: briefRecord.createdBy,
+    });
+    res.json(model);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    res.status(500).json({ error: message });
+  }
+}
+
+/**
+ * POST /admin/briefs/:id/approve — run the full approval orchestration.
+ */
+export async function handleApproveBrief(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  try {
+    const id = req.params.id as string;
+    const briefRecord = await getProcess(id);
+    if (!briefRecord || briefRecord.definition.type !== "civic.brief") {
+      res.status(404).json({ error: "Brief not found" });
+      return;
+    }
+
+    const state = briefState(briefRecord);
+    if (state.publication_status !== "pending") {
+      res.status(409).json({
+        error: `Brief is already ${state.publication_status}.`,
+      });
+      return;
+    }
+
+    const recipients = parseRecipients(process.env.BOARD_RECIPIENT_EMAIL);
+    if (recipients.length === 0) {
+      res.status(503).json({
+        error:
+          "Approval unavailable: BOARD_RECIPIENT_EMAIL is not configured on the server.",
+      });
+      return;
+    }
+
+    const actor = getAuthUser(res).id;
+    const ctx = {
+      process_id: briefRecord.id,
+      hub_id: briefRecord.hubId,
+      jurisdiction: briefRecord.jurisdiction,
+      emit: emitEvent,
+    };
+
+    // Closure called by the brief module once the brief reaches "published".
+    // Loads the linked vote, calls the vote module's finalizeVote directly
+    // (library-only; no HTTP path), then persists the vote.
+    const finalizeLinkedVote = async (voteId: string, byActor: string) => {
+      const voteRecord = await getProcess(voteId);
+      if (!voteRecord) {
+        throw new Error(`Linked vote not found: ${voteId}`);
+      }
+      if (voteRecord.definition.type !== "civic.vote") {
+        throw new Error(
+          `Linked process ${voteId} is not a civic.vote (type=${voteRecord.definition.type})`,
+        );
+      }
+      if (voteRecord.status === "finalized") {
+        // Idempotency: if the vote was already finalized (e.g. a prior
+        // approval attempt succeeded at this step), skip cleanly.
+        return;
+      }
+      const voteCtx = {
+        process_id: voteRecord.id,
+        hub_id: voteRecord.hubId,
+        jurisdiction: voteRecord.jurisdiction,
+        emit: emitEvent,
+      };
+      await finalizeVote(voteState(voteRecord), byActor, voteCtx);
+      voteRecord.status = voteState(voteRecord).status;
+      await saveProcessState(voteRecord);
+    };
+
+    await approveBrief(state, actor, ctx, {
+      recipients,
+      hubLabel: HUB_LABEL,
+      publicBriefUrl: publicBriefUrl(briefRecord.id),
+      sendEmail,
+      finalizeLinkedVote,
+    });
+
+    // Persist brief mutations (publication_status, timestamps, delivered_to).
+    // Also advance process-level status to match: published briefs are
+    // terminal, i.e. "finalized" in the spec's state machine.
+    briefRecord.status = "finalized";
+    await saveProcessState(briefRecord);
+
+    const model = getAdminReadModel(state, {
+      id: briefRecord.id,
+      title: briefRecord.title,
+      createdAt: briefRecord.createdAt,
+      createdBy: briefRecord.createdBy,
+    });
+    res.json({ message: "Brief approved and published.", brief: model });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    res.status(500).json({ error: message });
+  }
+}

--- a/src/controllers/adminBriefController.ts
+++ b/src/controllers/adminBriefController.ts
@@ -39,7 +39,8 @@ import {
   saveProcessState,
 } from "../services/processService.js";
 import { getAuthUser } from "../middleware/auth.js";
-import { sendEmail, parseRecipients } from "../services/mailer.js";
+import { sendEmail } from "../services/mailer.js";
+import { getBriefRecipients } from "../services/hubSettings.js";
 import { uiBaseUrl } from "../utils/baseUrl.js";
 
 const HUB_LABEL = "Floyd Civic Hub";
@@ -207,11 +208,15 @@ export async function handleApproveBrief(
       return;
     }
 
-    const recipients = parseRecipients(process.env.BOARD_RECIPIENT_EMAIL);
+    // Recipients: admin-configured DB value first, env var (BOARD_RECIPIENT_EMAIL)
+    // as safety-net fallback so existing deploys keep working before an admin
+    // has opened the settings panel for the first time.
+    const recipients = await getBriefRecipients();
     if (recipients.length === 0) {
       res.status(503).json({
         error:
-          "Approval unavailable: BOARD_RECIPIENT_EMAIL is not configured on the server.",
+          "Approval unavailable: no brief recipients configured. Set them in " +
+          "Admin → Civic Briefs → Settings (or as BOARD_RECIPIENT_EMAIL env var).",
       });
       return;
     }

--- a/src/controllers/adminSettingsController.ts
+++ b/src/controllers/adminSettingsController.ts
@@ -1,0 +1,61 @@
+// Admin settings controller — read/write admin-configurable hub settings.
+//
+// Slice 3 exposes only brief recipient emails. More settings can be added
+// by extending the SettingsResponse shape and the PATCH body handler.
+
+import { Request, Response } from "express";
+import {
+  getBriefRecipients,
+  setBriefRecipients,
+} from "../services/hubSettings.js";
+import { getAuthUser } from "../middleware/auth.js";
+
+interface SettingsResponse {
+  brief_recipient_emails: string[];
+}
+
+async function loadSettings(): Promise<SettingsResponse> {
+  return {
+    brief_recipient_emails: await getBriefRecipients(),
+  };
+}
+
+export async function handleGetSettings(
+  _req: Request,
+  res: Response,
+): Promise<void> {
+  try {
+    res.json(await loadSettings());
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    res.status(500).json({ error: message });
+  }
+}
+
+export async function handlePatchSettings(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  try {
+    const actor = getAuthUser(res).id;
+    const body = (req.body ?? {}) as { brief_recipient_emails?: unknown };
+
+    if (body.brief_recipient_emails !== undefined) {
+      if (!Array.isArray(body.brief_recipient_emails)) {
+        res.status(400).json({
+          error: "brief_recipient_emails must be an array of strings.",
+        });
+        return;
+      }
+      const input = body.brief_recipient_emails.filter(
+        (e): e is string => typeof e === "string",
+      );
+      await setBriefRecipients(input, actor);
+    }
+
+    res.json(await loadSettings());
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    res.status(500).json({ error: message });
+  }
+}

--- a/src/controllers/briefController.ts
+++ b/src/controllers/briefController.ts
@@ -1,0 +1,41 @@
+// Brief controller — public read endpoint for published Civic Briefs.
+//
+// Only briefs in publication_status = "published" are returned. Pending
+// and approved (delivered-but-not-yet-public) briefs return 404 so they
+// stay invisible to the public until admin publishes.
+
+import { Request, Response } from "express";
+import { getProcess } from "../services/processService.js";
+import {
+  getPublicReadModel,
+  type BriefProcessState,
+} from "../modules/civic.brief/index.js";
+
+export async function handleGetBrief(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  try {
+    const id = req.params.id as string;
+    const process = await getProcess(id);
+    if (!process || process.definition.type !== "civic.brief") {
+      res.status(404).json({ error: "Brief not found" });
+      return;
+    }
+    const state = process.state as unknown as BriefProcessState;
+    const model = getPublicReadModel(state, {
+      id: process.id,
+      title: process.title,
+      createdAt: process.createdAt,
+    });
+    if (!model) {
+      // Pending or approved-but-not-published — invisible to the public.
+      res.status(404).json({ error: "Brief not found" });
+      return;
+    }
+    res.json(model);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    res.status(500).json({ error: message });
+  }
+}

--- a/src/controllers/discoveryController.ts
+++ b/src/controllers/discoveryController.ts
@@ -3,6 +3,7 @@
 
 import { Request, Response } from "express";
 import { baseUrl } from "../utils/baseUrl.js";
+import { getRegisteredTypes } from "../processes/registry.js";
 
 export function handleDiscoveryManifest(_req: Request, res: Response): void {
   const hub = baseUrl();
@@ -23,7 +24,7 @@ export function handleDiscoveryManifest(_req: Request, res: Response): void {
     feeds: {
       events: `${hub}/events`,
     },
-    capabilities: ["civic.vote", "civic.proposal"],
+    capabilities: getRegisteredTypes(),
     spec: {
       process: "civic-process-spec-v0.1",
       event: "civic-event-spec-v0.1",

--- a/src/controllers/processController.ts
+++ b/src/controllers/processController.ts
@@ -101,7 +101,15 @@ export async function handleListProcesses(
   res: Response,
 ): Promise<void> {
   try {
-    res.json(await listProcessSummaries());
+    const all = await listProcessSummaries();
+    // Public list: hide civic.brief processes that aren't yet published.
+    // Pending / approved briefs are an admin-facing concern and must not be
+    // visible to the public before the admin approval step completes.
+    const filtered = all.filter((p) => {
+      if ((p as { type?: string }).type !== "civic.brief") return true;
+      return (p as { publication_status?: string }).publication_status === "published";
+    });
+    res.json(filtered);
   } catch (err) {
     const message = err instanceof Error ? err.message : "Unknown error";
     res.status(500).json({ error: message });

--- a/src/events/eventEmitter.ts
+++ b/src/events/eventEmitter.ts
@@ -9,7 +9,7 @@
 import { CivicEvent, CreateEventInput } from "../models/event.js";
 import { appendEvent } from "./eventStore.js";
 import { generateId } from "../utils/id.js";
-import { baseUrl } from "../utils/baseUrl.js";
+import { baseUrl, uiBaseUrl } from "../utils/baseUrl.js";
 
 /**
  * Create and durably store a spec-compliant civic event.
@@ -20,6 +20,11 @@ import { baseUrl } from "../utils/baseUrl.js";
  */
 export async function emitEvent(input: CreateEventInput): Promise<CivicEvent> {
   const hub = baseUrl();
+  const ui = uiBaseUrl();
+  // action_url is the user-facing UI URL (per Civic Event Spec §3 — "link to
+  // take action"). Defaults to /process/:id; callers can override via
+  // action_url_path when a process type has a distinct public page.
+  const path = input.action_url_path ?? `/process/${input.process_id}`;
   const event: CivicEvent = {
     id: generateId("evt"),
     version: "1.0",
@@ -28,7 +33,7 @@ export async function emitEvent(input: CreateEventInput): Promise<CivicEvent> {
     process_id: input.process_id,
     actor: input.actor,
     jurisdiction: input.jurisdiction,
-    action_url: `${hub}/process/${input.process_id}`,
+    action_url: `${ui}${path}`,
     source: {
       hub_id: input.hub_id,
       hub_url: hub,

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -36,6 +36,12 @@ export interface CivicEvent {
 /**
  * Input for emitEvent() — callers provide the minimum required fields.
  * The emitter fills in id, version, timestamp, source, action_url, and meta.
+ *
+ * Callers MAY override `action_url_path` when a process type's user-facing
+ * URL differs from the default `/process/:id`. The path is prefixed with
+ * the hub's UI base URL by the emitter. For example, civic.brief uses
+ * `action_url_path: /brief/:id` so feed posts link to the public brief
+ * page instead of the process detail view.
  */
 export interface CreateEventInput {
   event_type: string;
@@ -46,4 +52,5 @@ export interface CreateEventInput {
   data: Record<string, unknown>;
   dedupe_key?: string;
   visibility?: "public" | "restricted";
+  action_url_path?: string; // e.g. "/brief/abc123"; defaults to "/process/:id"
 }

--- a/src/modules/civic.brief/email.ts
+++ b/src/modules/civic.brief/email.ts
@@ -42,15 +42,10 @@ function renderText(
   for (const p of c.position_breakdown) {
     lines.push(`  • ${p.option_label}: ${p.count} (${p.percentage}%)`);
   }
-  if (c.concerns.length > 0) {
+  if (c.comments.length > 0) {
     lines.push("");
-    lines.push("Concerns raised:");
-    for (const concern of c.concerns) lines.push(`  • ${concern}`);
-  }
-  if (c.suggestions.length > 0) {
-    lines.push("");
-    lines.push("Suggestions:");
-    for (const s of c.suggestions) lines.push(`  • ${s}`);
+    lines.push("Community comments:");
+    for (const comment of c.comments) lines.push(`  • ${comment}`);
   }
   if (c.admin_notes.trim().length > 0) {
     lines.push("");
@@ -75,11 +70,8 @@ function renderHtml(
         `<li><strong>${escape(p.option_label)}:</strong> ${p.count} (${p.percentage}%)</li>`,
     )
     .join("");
-  const concerns = c.concerns.length
-    ? `<h3>Concerns raised</h3><ul>${c.concerns.map((x) => `<li>${escape(x)}</li>`).join("")}</ul>`
-    : "";
-  const suggestions = c.suggestions.length
-    ? `<h3>Suggestions</h3><ul>${c.suggestions.map((x) => `<li>${escape(x)}</li>`).join("")}</ul>`
+  const comments = c.comments.length
+    ? `<h3>Community comments</h3><ul>${c.comments.map((x) => `<li>${escape(x)}</li>`).join("")}</ul>`
     : "";
   const adminNotes = c.admin_notes.trim().length
     ? `<h3>Notes from the Civic Hub</h3><p>${escape(c.admin_notes.trim()).replace(/\n/g, "<br/>")}</p>`
@@ -92,8 +84,7 @@ function renderHtml(
   <p><strong>Participation:</strong> ${participants}</p>
   <h3>Positions</h3>
   <ul>${positions}</ul>
-  ${concerns}
-  ${suggestions}
+  ${comments}
   ${adminNotes}
   <hr style="border:none; border-top:1px solid #e5e5e5; margin:24px 0;"/>
   <p><a href="${escape(options.publicUrl)}">View this brief online</a></p>

--- a/src/modules/civic.brief/email.ts
+++ b/src/modules/civic.brief/email.ts
@@ -1,0 +1,123 @@
+// civic.brief module — email formatting
+//
+// Pure functions that turn a BriefProcessState into email subject + body
+// pair. Delivery is the host hub's responsibility (see SendEmailFn in
+// models.ts).
+
+import type { BriefContent, BriefProcessState } from "./models.js";
+
+export interface BriefEmail {
+  subject: string;
+  html: string;
+  text: string;
+}
+
+export function formatBriefEmail(
+  state: BriefProcessState,
+  options: {
+    hubLabel: string;           // e.g. "Floyd Civic Hub"
+    publicUrl: string;          // e.g. "https://example.org/brief/abc123"
+  },
+): BriefEmail {
+  const subject = `${options.hubLabel} — Civic Brief: ${state.content.title}`;
+  return {
+    subject,
+    text: renderText(state, options),
+    html: renderHtml(state, options),
+  };
+}
+
+function renderText(
+  state: BriefProcessState,
+  options: { hubLabel: string; publicUrl: string },
+): string {
+  const c = state.content;
+  const lines: string[] = [];
+  lines.push(c.title);
+  lines.push("=".repeat(c.title.length));
+  lines.push("");
+  lines.push(`Participation: ${c.participation_count} resident${c.participation_count === 1 ? "" : "s"}`);
+  lines.push("");
+  lines.push("Positions:");
+  for (const p of c.position_breakdown) {
+    lines.push(`  • ${p.option_label}: ${p.count} (${p.percentage}%)`);
+  }
+  if (c.concerns.length > 0) {
+    lines.push("");
+    lines.push("Concerns raised:");
+    for (const concern of c.concerns) lines.push(`  • ${concern}`);
+  }
+  if (c.suggestions.length > 0) {
+    lines.push("");
+    lines.push("Suggestions:");
+    for (const s of c.suggestions) lines.push(`  • ${s}`);
+  }
+  if (c.admin_notes.trim().length > 0) {
+    lines.push("");
+    lines.push("Notes from the Civic Hub:");
+    lines.push(c.admin_notes.trim());
+  }
+  lines.push("");
+  lines.push(`View online: ${options.publicUrl}`);
+  lines.push("");
+  lines.push(`— ${options.hubLabel}`);
+  return lines.join("\n");
+}
+
+function renderHtml(
+  state: BriefProcessState,
+  options: { hubLabel: string; publicUrl: string },
+): string {
+  const c = state.content;
+  const positions = c.position_breakdown
+    .map(
+      (p) =>
+        `<li><strong>${escape(p.option_label)}:</strong> ${p.count} (${p.percentage}%)</li>`,
+    )
+    .join("");
+  const concerns = c.concerns.length
+    ? `<h3>Concerns raised</h3><ul>${c.concerns.map((x) => `<li>${escape(x)}</li>`).join("")}</ul>`
+    : "";
+  const suggestions = c.suggestions.length
+    ? `<h3>Suggestions</h3><ul>${c.suggestions.map((x) => `<li>${escape(x)}</li>`).join("")}</ul>`
+    : "";
+  const adminNotes = c.admin_notes.trim().length
+    ? `<h3>Notes from the Civic Hub</h3><p>${escape(c.admin_notes.trim()).replace(/\n/g, "<br/>")}</p>`
+    : "";
+  const participants = `${c.participation_count} resident${c.participation_count === 1 ? "" : "s"}`;
+  return `<!doctype html>
+<html><body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; color:#1a1a1a; max-width:640px; margin:0 auto; padding:24px;">
+  <h1 style="font-size:22px; margin:0 0 8px;">${escape(c.title)}</h1>
+  <p style="color:#555; margin:0 0 16px;">Civic Brief — ${options.hubLabel}</p>
+  <p><strong>Participation:</strong> ${participants}</p>
+  <h3>Positions</h3>
+  <ul>${positions}</ul>
+  ${concerns}
+  ${suggestions}
+  ${adminNotes}
+  <hr style="border:none; border-top:1px solid #e5e5e5; margin:24px 0;"/>
+  <p><a href="${escape(options.publicUrl)}">View this brief online</a></p>
+  <p style="color:#888; font-size:12px;">— ${options.hubLabel}</p>
+</body></html>`;
+}
+
+function escape(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/**
+ * Human-readable one-liner for a brief content block, useful for logs and
+ * the feed post summary.
+ */
+export function headlineFor(content: BriefContent): string {
+  if (content.position_breakdown.length === 0 || content.participation_count === 0) {
+    return "No participation recorded.";
+  }
+  const top = content.position_breakdown[0];
+  return `${top.option_label}: ${top.count} of ${content.participation_count} (${top.percentage}%)`;
+}

--- a/src/modules/civic.brief/events.ts
+++ b/src/modules/civic.brief/events.ts
@@ -1,0 +1,142 @@
+// civic.brief module — event emission helpers
+//
+// Maps lifecycle transitions and admin actions to canonical event types
+// per Civic Event Spec v0.1 §7. All events emitted through the host hub's
+// emit callback, which handles ID, timestamp, source, and URL construction.
+
+import type { BriefProcessContext, BriefProcessState } from "./models.js";
+
+function briefPath(process_id: string): string {
+  return `/brief/${process_id}`;
+}
+
+export async function emitBriefCreated(
+  ctx: BriefProcessContext,
+  actor: string,
+  state: BriefProcessState,
+): Promise<void> {
+  await ctx.emit({
+    event_type: "civic.process.created",
+    actor,
+    process_id: ctx.process_id,
+    hub_id: ctx.hub_id,
+    jurisdiction: ctx.jurisdiction,
+    action_url_path: briefPath(ctx.process_id),
+    data: {
+      process: {
+        type: "civic.brief",
+        title: state.content.title,
+        source_process_id: state.source_process_id,
+      },
+    },
+  });
+}
+
+/**
+ * Emitted immediately after brief creation. The brief's aggregation step
+ * is the generation of structured content from the underlying vote; it
+ * completes synchronously at creation time, so the event fires together
+ * with `created`.
+ */
+export async function emitBriefAggregationCompleted(
+  ctx: BriefProcessContext,
+  actor: string,
+  state: BriefProcessState,
+): Promise<void> {
+  await ctx.emit({
+    event_type: "civic.process.aggregation_completed",
+    actor,
+    process_id: ctx.process_id,
+    hub_id: ctx.hub_id,
+    jurisdiction: ctx.jurisdiction,
+    action_url_path: briefPath(ctx.process_id),
+    data: {
+      aggregation_method: "summarization",
+      participant_count: state.content.participation_count,
+      result_type: "summary",
+      result_summary: summarizePositions(state),
+    },
+  });
+}
+
+export async function emitBriefUpdated(
+  ctx: BriefProcessContext,
+  actor: string,
+  state: BriefProcessState,
+): Promise<void> {
+  await ctx.emit({
+    event_type: "civic.process.updated",
+    actor,
+    process_id: ctx.process_id,
+    hub_id: ctx.hub_id,
+    jurisdiction: ctx.jurisdiction,
+    action_url_path: briefPath(ctx.process_id),
+    data: {
+      brief: {
+        publication_status: state.publication_status,
+        concerns_count: state.content.concerns.length,
+        suggestions_count: state.content.suggestions.length,
+        has_admin_notes: state.content.admin_notes.trim().length > 0,
+      },
+    },
+  });
+}
+
+/**
+ * Phase 5 (Outcome / Decision) event per Civic Process Spec §10. The brief
+ * records the advisory outcome of the linked vote.
+ */
+export async function emitBriefOutcomeRecorded(
+  ctx: BriefProcessContext,
+  actor: string,
+  state: BriefProcessState,
+): Promise<void> {
+  await ctx.emit({
+    event_type: "civic.process.outcome_recorded",
+    actor,
+    process_id: ctx.process_id,
+    hub_id: ctx.hub_id,
+    jurisdiction: ctx.jurisdiction,
+    action_url_path: briefPath(ctx.process_id),
+    data: {
+      outcome_type: "advisory",
+      outcome_description: summarizePositions(state),
+      linked_process_id: state.source_process_id,
+    },
+  });
+}
+
+/**
+ * Phase 6 (Publication) event per Civic Process Spec §6. Makes the brief
+ * visible to the public feed. The feed renders this as a "Civic Brief
+ * delivered: [title]" post.
+ */
+export async function emitBriefResultPublished(
+  ctx: BriefProcessContext,
+  actor: string,
+  state: BriefProcessState,
+): Promise<void> {
+  await ctx.emit({
+    event_type: "civic.process.result_published",
+    actor,
+    process_id: ctx.process_id,
+    hub_id: ctx.hub_id,
+    jurisdiction: ctx.jurisdiction,
+    action_url_path: briefPath(ctx.process_id),
+    data: {
+      brief_id: ctx.process_id,
+      source_process_id: state.source_process_id,
+      participation_count: state.content.participation_count,
+      headline_result: summarizePositions(state),
+    },
+  });
+}
+
+function summarizePositions(state: BriefProcessState): string {
+  const positions = state.content.position_breakdown;
+  if (positions.length === 0 || state.content.participation_count === 0) {
+    return "No participation recorded.";
+  }
+  const top = positions[0];
+  return `${top.option_label}: ${top.count} of ${state.content.participation_count} (${top.percentage}%)`;
+}

--- a/src/modules/civic.brief/events.ts
+++ b/src/modules/civic.brief/events.ts
@@ -74,8 +74,7 @@ export async function emitBriefUpdated(
     data: {
       brief: {
         publication_status: state.publication_status,
-        concerns_count: state.content.concerns.length,
-        suggestions_count: state.content.suggestions.length,
+        comments_count: state.content.comments.length,
         has_admin_notes: state.content.admin_notes.trim().length > 0,
       },
     },

--- a/src/modules/civic.brief/index.ts
+++ b/src/modules/civic.brief/index.ts
@@ -1,0 +1,63 @@
+// civic.brief module — public surface
+//
+// A hub wishing to offer Civic Briefs registers this module via the
+// process registry. A hub that doesn't want briefs simply doesn't
+// register it — no other code paths depend on the module being present.
+
+export type {
+  BriefActionOutcome,
+  BriefContent,
+  BriefContentPatch,
+  BriefPositionBreakdown,
+  BriefProcessContext,
+  BriefProcessState,
+  BriefPublicationStatus,
+  CreateBriefFromVoteInput,
+  EmitEventFn,
+  FinalizeLinkedVoteFn,
+  SendEmailFn,
+} from "./models.js";
+
+export {
+  approveBrief,
+  createBriefState,
+  editBrief,
+  emitCreationEvents,
+  getAdminReadModel,
+  getAdminSummary,
+  getPublicReadModel,
+} from "./service.js";
+
+export {
+  assertPublicationTransition,
+  canApprove,
+  canEdit,
+  isPublished,
+} from "./lifecycle.js";
+
+export { formatBriefEmail, headlineFor } from "./email.js";
+
+export const PROCESS_DESCRIPTOR = {
+  type: "civic.brief",
+  version: "0.1",
+  lifecycle: {
+    states: ["active", "closed", "finalized"],
+    publication_sub_states: ["pending", "approved", "published"],
+    paths: {
+      standard: ["active", "closed", "finalized"],
+    },
+  },
+  actions: [
+    // All brief transitions happen via the admin HTTP surface, not process
+    // actions on /process/:id/action. The admin routes orchestrate the
+    // approval sequence; briefs are intentionally not exposed through the
+    // generic action dispatcher.
+  ],
+  events: [
+    "civic.process.created",
+    "civic.process.aggregation_completed",
+    "civic.process.updated",
+    "civic.process.outcome_recorded",
+    "civic.process.result_published",
+  ],
+} as const;

--- a/src/modules/civic.brief/lifecycle.ts
+++ b/src/modules/civic.brief/lifecycle.ts
@@ -1,0 +1,49 @@
+// civic.brief module — lifecycle transitions
+//
+// A brief's lifecycle is narrower than a vote's because briefs don't have
+// a participation window. Once created, a brief sits in `active` status
+// with publication_status="pending" while it awaits admin review.
+// Approval walks it through closed → finalized as publication completes.
+//
+// Process-level status transitions (draft | active | closed | finalized):
+//
+//   (implicit draft) → active      at creation
+//   active → closed                on admin approval (brief review done)
+//   closed → finalized             after email + result_published emit
+//
+// Publication sub-state (pending | approved | published) mirrors the
+// admin workflow more finely than process status alone can.
+
+import type { BriefProcessState, BriefPublicationStatus } from "./models.js";
+
+export function canEdit(state: BriefProcessState): boolean {
+  return state.publication_status === "pending";
+}
+
+export function canApprove(state: BriefProcessState): boolean {
+  return state.publication_status === "pending";
+}
+
+export function isPublished(state: BriefProcessState): boolean {
+  return state.publication_status === "published";
+}
+
+/**
+ * Validate an intended publication_status transition. Throws on invalid
+ * transitions so callers don't have to re-encode the rules.
+ */
+export function assertPublicationTransition(
+  from: BriefPublicationStatus,
+  to: BriefPublicationStatus,
+): void {
+  const allowed: Record<BriefPublicationStatus, BriefPublicationStatus[]> = {
+    pending: ["approved"],
+    approved: ["published"],
+    published: [],
+  };
+  if (!allowed[from].includes(to)) {
+    throw new Error(
+      `Invalid brief publication transition: ${from} → ${to}`,
+    );
+  }
+}

--- a/src/modules/civic.brief/models.ts
+++ b/src/modules/civic.brief/models.ts
@@ -24,8 +24,13 @@ export interface BriefContent {
   title: string;
   participation_count: number;
   position_breakdown: BriefPositionBreakdown[];
-  concerns: string[];
-  suggestions: string[];
+  /**
+   * Community comments surfaced alongside the brief — a single flat list
+   * rather than separate concern/suggestion buckets. Slice 3.5 will
+   * populate this from the civic.input stream; for now it starts empty
+   * and the admin types entries in during review.
+   */
+  comments: string[];
   admin_notes: string;
 }
 
@@ -115,7 +120,6 @@ export interface CreateBriefFromVoteInput {
 
 /** Partial content update used by PATCH /admin/briefs/:id. */
 export interface BriefContentPatch {
-  concerns?: string[];
-  suggestions?: string[];
+  comments?: string[];
   admin_notes?: string;
 }

--- a/src/modules/civic.brief/models.ts
+++ b/src/modules/civic.brief/models.ts
@@ -1,0 +1,121 @@
+// civic.brief module — type definitions
+//
+// A Civic Brief is a structured summary of a completed vote process,
+// intended for delivery to decision-makers (e.g. Board of Supervisors)
+// and public publication. Briefs are themselves civic processes — they
+// live in the same process store as votes and proposals and follow the
+// spec's lifecycle model (Phases 0, 4, 5, 6 per Civic Process Spec §5).
+//
+// This module is self-contained and portable across hubs. The host hub
+// provides callbacks for event emission, email delivery, and finalizing
+// the linked vote. The module itself has no knowledge of Express, the
+// process registry, Supabase, or nodemailer.
+
+export type BriefPublicationStatus = "pending" | "approved" | "published";
+
+export interface BriefPositionBreakdown {
+  option_id: string;
+  option_label: string;
+  count: number;
+  percentage: number;
+}
+
+export interface BriefContent {
+  title: string;
+  participation_count: number;
+  position_breakdown: BriefPositionBreakdown[];
+  concerns: string[];
+  suggestions: string[];
+  admin_notes: string;
+}
+
+/**
+ * Shape of Process.state for a civic.brief process.
+ *
+ * The process-level `status` field (draft | active | closed | finalized)
+ * tracks the lifecycle state machine. The brief-specific
+ * `publication_status` tracks the admin review sub-state:
+ *
+ *   pending   — auto-generated, awaiting admin review
+ *   approved  — admin approved, email sent, not yet published publicly
+ *   published — final: visible on public /brief/:id page, feed post emitted
+ */
+export interface BriefProcessState {
+  type: "civic.brief";
+  source_process_id: string;             // the vote this brief summarizes
+  publication_status: BriefPublicationStatus;
+  generated_at: string;                  // ISO 8601
+  approved_at: string | null;
+  published_at: string | null;
+  content: BriefContent;
+  delivered_to: string[];                // email recipients recorded on approval
+}
+
+/**
+ * Event emission callback — injected by the host hub. Matches the shape
+ * used by civic.vote/models.ts EmitEventFn, extended with the optional
+ * action_url_path so briefs can point events at the public brief page.
+ */
+export interface EmitEventFn {
+  (input: {
+    event_type: string;
+    actor: string;
+    process_id: string;
+    hub_id: string;
+    jurisdiction: string;
+    data: Record<string, unknown>;
+    action_url_path?: string;
+  }): Promise<unknown>;
+}
+
+/**
+ * Email delivery callback — injected by the host hub. Returns normally on
+ * success; throws on delivery failure. The module halts the approval flow
+ * if this throws.
+ */
+export interface SendEmailFn {
+  (message: {
+    to: string[];
+    subject: string;
+    html: string;
+    text: string;
+  }): Promise<void>;
+}
+
+/**
+ * Finalize-linked-vote callback — injected by the host hub. Called after
+ * the brief transitions to "published". Signals the vote module to
+ * finalize the underlying vote process and emit its result_published.
+ * The hub wires this to call `finalizeVote` on the vote process.
+ */
+export interface FinalizeLinkedVoteFn {
+  (voteProcessId: string, actor: string): Promise<void>;
+}
+
+export interface BriefProcessContext {
+  process_id: string;
+  hub_id: string;
+  jurisdiction: string;
+  emit: EmitEventFn;
+}
+
+/** Standard outcome returned by module actions. */
+export interface BriefActionOutcome {
+  state: BriefProcessState;
+  result: Record<string, unknown>;
+}
+
+/** Input the hub passes when creating a brief from a closed vote. */
+export interface CreateBriefFromVoteInput {
+  source_process_id: string;
+  vote_title: string;
+  tally: Record<string, number>; // option → count
+  total_votes: number;
+}
+
+/** Partial content update used by PATCH /admin/briefs/:id. */
+export interface BriefContentPatch {
+  concerns?: string[];
+  suggestions?: string[];
+  admin_notes?: string;
+}

--- a/src/modules/civic.brief/service.ts
+++ b/src/modules/civic.brief/service.ts
@@ -57,8 +57,8 @@ function generateBriefContent(input: CreateBriefFromVoteInput): BriefContent {
     title: input.vote_title,
     participation_count: total,
     position_breakdown,
-    concerns: [], // populated by admin during review (see HANDOFF.md)
-    suggestions: [],
+    // Empty at generation; Slice 3.5 will populate from civic.input.
+    comments: [],
     admin_notes: "",
   };
 }
@@ -90,11 +90,8 @@ export async function editBrief(
   }
 
   const content = { ...state.content };
-  if (patch.concerns !== undefined) {
-    content.concerns = sanitizeList(patch.concerns);
-  }
-  if (patch.suggestions !== undefined) {
-    content.suggestions = sanitizeList(patch.suggestions);
+  if (patch.comments !== undefined) {
+    content.comments = sanitizeList(patch.comments);
   }
   if (patch.admin_notes !== undefined) {
     content.admin_notes = patch.admin_notes;
@@ -243,8 +240,7 @@ export function getPublicReadModel(
     source_process_id: state.source_process_id,
     participation_count: state.content.participation_count,
     position_breakdown: state.content.position_breakdown,
-    concerns: state.content.concerns,
-    suggestions: state.content.suggestions,
+    comments: state.content.comments,
     admin_notes: state.content.admin_notes,
     generated_at: state.generated_at,
     published_at: state.published_at,

--- a/src/modules/civic.brief/service.ts
+++ b/src/modules/civic.brief/service.ts
@@ -1,0 +1,271 @@
+// civic.brief module — service functions (pure / orchestration)
+//
+// Pure state transitions and the approval orchestration sequence. No I/O
+// lives here beyond what the injected callbacks perform. The host hub is
+// responsible for persisting state changes after these functions return.
+
+import type {
+  BriefActionOutcome,
+  BriefContent,
+  BriefContentPatch,
+  BriefProcessContext,
+  BriefProcessState,
+  CreateBriefFromVoteInput,
+  FinalizeLinkedVoteFn,
+  SendEmailFn,
+} from "./models.js";
+import { assertPublicationTransition, canApprove, canEdit } from "./lifecycle.js";
+import {
+  emitBriefAggregationCompleted,
+  emitBriefCreated,
+  emitBriefOutcomeRecorded,
+  emitBriefResultPublished,
+  emitBriefUpdated,
+} from "./events.js";
+import { formatBriefEmail } from "./email.js";
+
+/**
+ * Build the initial BriefProcessState from a completed vote. Generation
+ * is deterministic and synchronous: participation count = distinct voters,
+ * position breakdown = sorted tally, concerns/suggestions empty (see
+ * HANDOFF.md for the data-gap rationale).
+ */
+export function createBriefState(input: CreateBriefFromVoteInput): BriefProcessState {
+  const content = generateBriefContent(input);
+  return {
+    type: "civic.brief",
+    source_process_id: input.source_process_id,
+    publication_status: "pending",
+    generated_at: new Date().toISOString(),
+    approved_at: null,
+    published_at: null,
+    content,
+    delivered_to: [],
+  };
+}
+
+function generateBriefContent(input: CreateBriefFromVoteInput): BriefContent {
+  const entries = Object.entries(input.tally).sort((a, b) => b[1] - a[1]);
+  const total = input.total_votes;
+  const position_breakdown = entries.map(([option_id, count]) => ({
+    option_id,
+    option_label: option_id, // options are user-authored strings; id == label for MVP
+    count,
+    percentage: total > 0 ? Math.round((count / total) * 100) : 0,
+  }));
+  return {
+    title: input.vote_title,
+    participation_count: total,
+    position_breakdown,
+    concerns: [], // populated by admin during review (see HANDOFF.md)
+    suggestions: [],
+    admin_notes: "",
+  };
+}
+
+/** Emit the creation events. Called by the host hub once the brief row is persisted. */
+export async function emitCreationEvents(
+  ctx: BriefProcessContext,
+  actor: string,
+  state: BriefProcessState,
+): Promise<void> {
+  await emitBriefCreated(ctx, actor, state);
+  await emitBriefAggregationCompleted(ctx, actor, state);
+}
+
+/**
+ * Apply an admin edit to brief content. Rejects if the brief has already
+ * been approved. Emits `civic.process.updated`.
+ */
+export async function editBrief(
+  state: BriefProcessState,
+  actor: string,
+  patch: BriefContentPatch,
+  ctx: BriefProcessContext,
+): Promise<BriefActionOutcome> {
+  if (!canEdit(state)) {
+    throw new Error(
+      `Brief cannot be edited: publication_status is "${state.publication_status}"`,
+    );
+  }
+
+  const content = { ...state.content };
+  if (patch.concerns !== undefined) {
+    content.concerns = sanitizeList(patch.concerns);
+  }
+  if (patch.suggestions !== undefined) {
+    content.suggestions = sanitizeList(patch.suggestions);
+  }
+  if (patch.admin_notes !== undefined) {
+    content.admin_notes = patch.admin_notes;
+  }
+  state.content = content;
+
+  await emitBriefUpdated(ctx, actor, state);
+
+  return { state, result: { content } };
+}
+
+function sanitizeList(items: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of items) {
+    const trimmed = typeof raw === "string" ? raw.trim() : "";
+    if (trimmed.length === 0) continue;
+    if (seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    out.push(trimmed);
+  }
+  return out;
+}
+
+/**
+ * Run the approval sequence. Performs steps in order; if any step fails,
+ * halts and the caller is responsible for surfacing the error. Mutations
+ * happen on the passed-in state object.
+ *
+ * Sequence (Civic Process Spec Phases 5 → 6):
+ *   1. publication_status = approved, approved_at = now
+ *   2. send email (HALT on failure — brief stays "approved", no events emit)
+ *   3. record delivered_to
+ *   4. emit outcome_recorded
+ *   5. publication_status = published, published_at = now
+ *   6. emit result_published (brief)
+ *   7. finalize linked vote (which emits vote.result_published)
+ */
+export async function approveBrief(
+  state: BriefProcessState,
+  actor: string,
+  ctx: BriefProcessContext,
+  deps: {
+    recipients: string[];
+    hubLabel: string;
+    publicBriefUrl: string;
+    sendEmail: SendEmailFn;
+    finalizeLinkedVote: FinalizeLinkedVoteFn;
+  },
+): Promise<BriefActionOutcome> {
+  if (!canApprove(state)) {
+    throw new Error(
+      `Brief cannot be approved: publication_status is "${state.publication_status}"`,
+    );
+  }
+  if (deps.recipients.length === 0) {
+    throw new Error("Cannot approve brief: no email recipients configured (BOARD_RECIPIENT_EMAIL).");
+  }
+
+  // Step 1: transition to approved
+  assertPublicationTransition(state.publication_status, "approved");
+  state.publication_status = "approved";
+  state.approved_at = new Date().toISOString();
+
+  // Step 2: deliver email (halt on failure)
+  const email = formatBriefEmail(state, {
+    hubLabel: deps.hubLabel,
+    publicUrl: deps.publicBriefUrl,
+  });
+  await deps.sendEmail({
+    to: deps.recipients,
+    subject: email.subject,
+    html: email.html,
+    text: email.text,
+  });
+
+  // Step 3: record recipients
+  state.delivered_to = [...deps.recipients];
+
+  // Step 4: outcome recorded (Phase 5)
+  await emitBriefOutcomeRecorded(ctx, actor, state);
+
+  // Step 5: transition to published
+  assertPublicationTransition(state.publication_status, "published");
+  state.publication_status = "published";
+  state.published_at = new Date().toISOString();
+
+  // Step 6: result published (Phase 6 — the brief itself)
+  await emitBriefResultPublished(ctx, actor, state);
+
+  // Step 7: finalize the linked vote — emits vote.result_published
+  await deps.finalizeLinkedVote(state.source_process_id, actor);
+
+  return {
+    state,
+    result: {
+      publication_status: state.publication_status,
+      approved_at: state.approved_at,
+      published_at: state.published_at,
+      delivered_to: state.delivered_to,
+    },
+  };
+}
+
+/**
+ * Admin-facing read model (full brief detail).
+ */
+export function getAdminReadModel(
+  state: BriefProcessState,
+  processMeta: {
+    id: string;
+    title: string;
+    createdAt: string;
+    createdBy: string;
+  },
+): Record<string, unknown> {
+  return {
+    id: processMeta.id,
+    type: "civic.brief",
+    title: processMeta.title,
+    source_process_id: state.source_process_id,
+    publication_status: state.publication_status,
+    generated_at: state.generated_at,
+    approved_at: state.approved_at,
+    published_at: state.published_at,
+    content: state.content,
+    delivered_to: state.delivered_to,
+    created_at: processMeta.createdAt,
+    created_by: processMeta.createdBy,
+  };
+}
+
+/**
+ * Public read model (published briefs only). Excludes fields irrelevant or
+ * sensitive for public consumption (e.g. delivered_to email list).
+ */
+export function getPublicReadModel(
+  state: BriefProcessState,
+  processMeta: { id: string; title: string; createdAt: string },
+): Record<string, unknown> | null {
+  if (state.publication_status !== "published") return null;
+  return {
+    id: processMeta.id,
+    type: "civic.brief",
+    title: processMeta.title,
+    source_process_id: state.source_process_id,
+    participation_count: state.content.participation_count,
+    position_breakdown: state.content.position_breakdown,
+    concerns: state.content.concerns,
+    suggestions: state.content.suggestions,
+    admin_notes: state.content.admin_notes,
+    generated_at: state.generated_at,
+    published_at: state.published_at,
+  };
+}
+
+/** Summary used by admin listing. */
+export function getAdminSummary(
+  state: BriefProcessState,
+  processMeta: { id: string; title: string; createdAt: string },
+): Record<string, unknown> {
+  return {
+    id: processMeta.id,
+    type: "civic.brief",
+    title: processMeta.title,
+    source_process_id: state.source_process_id,
+    publication_status: state.publication_status,
+    participation_count: state.content.participation_count,
+    generated_at: state.generated_at,
+    approved_at: state.approved_at,
+    published_at: state.published_at,
+    created_at: processMeta.createdAt,
+  };
+}

--- a/src/modules/civic.vote/events.ts
+++ b/src/modules/civic.vote/events.ts
@@ -114,6 +114,43 @@ export async function emitEnded(
   });
 }
 
+/**
+ * Emit the Phase 4 (Aggregation) event. Per Civic Event Spec §7.6 and
+ * Civic Process Spec §9, this fires when raw participant inputs have been
+ * processed into structured results. For civic.vote, tallying IS the
+ * aggregation step, so this fires alongside `ended`.
+ */
+export async function emitAggregationCompleted(
+  ctx: EventContext,
+  actor: string,
+  result: VoteResult,
+  participant_count: number,
+): Promise<void> {
+  await ctx.emit({
+    event_type: "civic.process.aggregation_completed",
+    actor,
+    process_id: ctx.process_id,
+    hub_id: ctx.hub_id,
+    jurisdiction: ctx.jurisdiction,
+    data: {
+      aggregation_method: "tallying",
+      participant_count,
+      result_type: "tally",
+      result_summary: summarizeTally(result),
+    },
+  });
+}
+
+function summarizeTally(result: VoteResult): string {
+  const entries = Object.entries(result.tally).sort((a, b) => b[1] - a[1]);
+  if (entries.length === 0 || result.total_votes === 0) {
+    return "No votes recorded.";
+  }
+  const [topOption, topCount] = entries[0];
+  const pct = Math.round((topCount / result.total_votes) * 100);
+  return `${topOption}: ${topCount} of ${result.total_votes} (${pct}%)`;
+}
+
 export async function emitResultPublished(
   ctx: EventContext,
   actor: string,

--- a/src/modules/civic.vote/index.ts
+++ b/src/modules/civic.vote/index.ts
@@ -25,6 +25,7 @@ import {
   emitStarted,
   emitVoteSubmitted,
   emitEnded,
+  emitAggregationCompleted,
   emitResultPublished,
 } from "./events.js";
 
@@ -52,8 +53,7 @@ export const PROCESS_DESCRIPTOR = {
     { name: "process.unsupport", from: ["proposed"], to: null, description: "Remove endorsement (only before threshold is met)" },
     { name: "process.activate", from: ["draft", "threshold_met"], to: "active", description: "Open the voting window" },
     { name: "process.vote", from: ["active"], to: null, description: "Cast or change a vote" },
-    { name: "process.close", from: ["active"], to: "closed", description: "End the voting window" },
-    { name: "process.finalize", from: ["closed"], to: "finalized", description: "Compute and publish results" },
+    { name: "process.close", from: ["active"], to: "closed", description: "End the voting window; aggregation runs immediately" },
   ],
   config_schema: {
     support_threshold: { type: "number", default: 3, description: "Endorsements required before activation" },
@@ -66,6 +66,7 @@ export const PROCESS_DESCRIPTOR = {
     "civic.process.started",
     "civic.process.vote_submitted",
     "civic.process.ended",
+    "civic.process.aggregation_completed",
     "civic.process.result_published",
   ],
 } as const;
@@ -280,8 +281,13 @@ export async function submitVote(
 }
 
 /**
- * Close the vote — ends the voting window.
+ * Close the vote — ends the voting window and runs aggregation.
  * Transition: active → closed
+ *
+ * Emits Phase 3→4 boundary events: `ended` (participation closed) and
+ * `aggregation_completed` (tally produced). Does NOT emit
+ * `result_published` — that only fires once an accompanying civic.brief
+ * has been approved by an admin, via finalizeVote().
  */
 export async function closeVote(
   state: VoteProcessState,
@@ -292,8 +298,12 @@ export async function closeVote(
 
   state.status = "closed";
   const result = computeTally(state.votes, state.options);
+  // Tally is computed over distinct voter identities (keys of state.votes),
+  // so participant_count == Object.keys(state.votes).length.
+  const participantCount = Object.keys(state.votes).length;
 
   await emitEnded(ctx, actor, result);
+  await emitAggregationCompleted(ctx, actor, result, participantCount);
 
   return {
     state,
@@ -302,8 +312,14 @@ export async function closeVote(
 }
 
 /**
- * Finalize the vote — compute and publish results.
+ * Finalize the vote — publish the result.
  * Transition: closed → finalized
+ *
+ * Library-only entry point: there is no HTTP action wired to this. The
+ * civic.brief module's approval flow calls this directly once an admin
+ * has reviewed and approved the accompanying brief. Result publication is
+ * therefore gated on admin approval; no caller outside the brief flow
+ * should be able to reach this function.
  */
 export async function finalizeVote(
   state: VoteProcessState,

--- a/src/processes/briefProcess.ts
+++ b/src/processes/briefProcess.ts
@@ -1,0 +1,81 @@
+// civic.brief process handler — thin adapter around the civic.brief module.
+//
+// The handler registers `civic.brief` as a process type so briefs are
+// stored in the same process store as votes and proposals. Briefs are not
+// exposed through the generic `POST /process/:id/action` dispatcher —
+// their admin surface is `/admin/briefs/*`. This adapter therefore
+// accepts no actions; it exists to give the registry a way to
+// initialize state and produce read models for briefs alongside other
+// process types.
+
+import { Process, ProcessAction } from "../models/process.js";
+import { ProcessHandler } from "./types.js";
+import {
+  createBriefState,
+  getAdminReadModel,
+  getAdminSummary,
+  type BriefProcessState,
+  type CreateBriefFromVoteInput,
+} from "../modules/civic.brief/index.js";
+
+function getState(process: Process): BriefProcessState {
+  return process.state as unknown as BriefProcessState;
+}
+
+const briefProcess: ProcessHandler = {
+  type: "civic.brief",
+
+  initializeState(input: Record<string, unknown>): Record<string, unknown> {
+    // Briefs are always created programmatically (from a closed vote), so
+    // we expect the host hub to pass a CreateBriefFromVoteInput shape in
+    // the initialization input. Callers outside the vote-close flow are
+    // not supported.
+    const required = ["source_process_id", "vote_title", "tally", "total_votes"] as const;
+    for (const key of required) {
+      if (!(key in input)) {
+        throw new Error(
+          `civic.brief initializeState requires "${key}" — briefs can only be created by the vote-close flow.`,
+        );
+      }
+    }
+    const briefInput: CreateBriefFromVoteInput = {
+      source_process_id: input.source_process_id as string,
+      vote_title: input.vote_title as string,
+      tally: input.tally as Record<string, number>,
+      total_votes: input.total_votes as number,
+    };
+    return createBriefState(briefInput) as unknown as Record<string, unknown>;
+  },
+
+  async handleAction(
+    _process: Process,
+    action: ProcessAction,
+  ): Promise<Record<string, unknown>> {
+    // No HTTP actions reach briefs. Any attempt indicates a misrouting.
+    throw new Error(
+      `civic.brief does not accept process actions (received "${action.type}"). ` +
+        `Brief review happens via /admin/briefs/*.`,
+    );
+  },
+
+  getReadModel(process: Process): Record<string, unknown> {
+    const state = getState(process);
+    return getAdminReadModel(state, {
+      id: process.id,
+      title: process.title,
+      createdAt: process.createdAt,
+      createdBy: process.createdBy,
+    });
+  },
+
+  getSummary(process: Process): Record<string, unknown> {
+    const state = getState(process);
+    return getAdminSummary(state, {
+      id: process.id,
+      title: process.title,
+      createdAt: process.createdAt,
+    });
+  },
+};
+
+export default briefProcess;

--- a/src/processes/registry.ts
+++ b/src/processes/registry.ts
@@ -7,10 +7,16 @@
 import { ProcessHandler, ProcessFactory } from "./types.js";
 import voteProcess from "./voteProcess.js";
 import proposalProcess from "./proposalProcess.js";
+import briefProcess from "./briefProcess.js";
 
+// civic.brief is registered here but can be omitted by hubs that don't want
+// brief generation. When present, the vote adapter's process.close handler
+// spawns a brief after the vote closes. When absent, vote closes simply
+// terminate without a brief.
 const processRegistry: Record<string, ProcessHandler> = {
   "civic.vote": voteProcess,
   "civic.proposal": proposalProcess,
+  "civic.brief": briefProcess,
 };
 
 /**

--- a/src/processes/voteProcess.ts
+++ b/src/processes/voteProcess.ts
@@ -15,12 +15,14 @@ import {
   activate,
   submitVote,
   closeVote,
-  finalizeVote,
   getReadModel,
   getSummary,
   type VoteProcessState,
 } from "../modules/civic.vote/index.js";
 import { recordVote } from "../modules/civic.receipts/index.js";
+import type { BriefProcessState } from "../modules/civic.brief/index.js";
+import { emitBriefAggregationCompleted } from "../modules/civic.brief/events.js";
+import { getProcessFactory, getProcessHandler } from "./registry.js";
 
 // --- Helpers ---
 
@@ -39,6 +41,63 @@ function makeContext(process: Process) {
 
 function syncStatus(process: Process, state: VoteProcessState): void {
   process.status = state.status;
+}
+
+/**
+ * Spawn a civic.brief process from a just-closed vote and link the two
+ * via the parent's follow_up_process_ids array (Civic Process Spec §11.3).
+ *
+ * The generic process factory emits civic.process.created for the brief;
+ * we additionally fire the brief's aggregation_completed here so the
+ * spec's Phase 4 boundary is observable on the event feed.
+ */
+async function spawnBriefFromClosedVote(
+  voteProcess: Process,
+  closeResult: Record<string, unknown>,
+): Promise<Process> {
+  const factory = getProcessFactory();
+  const brief = await factory({
+    definition: { type: "civic.brief", version: "0.1" },
+    title: `Civic Brief: ${voteProcess.title}`,
+    description: voteProcess.description,
+    hubId: voteProcess.hubId,
+    jurisdiction: voteProcess.jurisdiction,
+    createdBy: "system",
+    state: {
+      source_process_id: voteProcess.id,
+      vote_title: voteProcess.title,
+      tally: closeResult.tally,
+      total_votes: closeResult.total_votes,
+    },
+  });
+
+  // Emit aggregation_completed for the brief. (civic.process.created is
+  // already emitted by the generic factory in processService.)
+  const briefState = brief.state as unknown as BriefProcessState;
+  await emitBriefAggregationCompleted(
+    {
+      process_id: brief.id,
+      hub_id: brief.hubId,
+      jurisdiction: brief.jurisdiction,
+      emit: emitEvent,
+    },
+    "system",
+    briefState,
+  );
+
+  // Link the parent vote to the new brief. This mutation of
+  // voteProcess.state is persisted by processService after handleAction
+  // returns. Per Civic Process Spec §11.3, follow_up_process_ids is the
+  // canonical parent→child linkage.
+  const voteState = voteProcess.state as unknown as VoteProcessState & {
+    follow_up_process_ids?: string[];
+  };
+  voteState.follow_up_process_ids = [
+    ...(voteState.follow_up_process_ids ?? []),
+    brief.id,
+  ];
+
+  return brief;
 }
 
 // --- Handler implementation ---
@@ -98,14 +157,22 @@ const voteProcess: ProcessHandler = {
         const outcome = await closeVote(state, action.actor, ctx);
         syncStatus(process, outcome.state);
         result = outcome.result;
+
+        // If civic.brief is registered, spawn a brief from the now-closed
+        // vote. Hubs that don't register civic.brief simply skip this step.
+        const briefHandler = getProcessHandler("civic.brief");
+        if (briefHandler) {
+          const brief = await spawnBriefFromClosedVote(process, outcome.result);
+          result = { ...result, brief_process_id: brief.id };
+        }
         break;
       }
-      case "process.finalize": {
-        const outcome = await finalizeVote(state, action.actor, ctx);
-        syncStatus(process, outcome.state);
-        result = outcome.result;
-        break;
-      }
+      // Note: there is intentionally no `process.finalize` action here.
+      // Finalization publishes the vote result, which must be gated on
+      // admin approval of the accompanying civic.brief. The brief module's
+      // approval flow calls `finalizeVote` directly as a library import;
+      // there is no HTTP path that publishes a vote result without
+      // approved-brief orchestration.
       default:
         throw new Error(`Unknown action type for civic.vote: ${action.type}`);
     }

--- a/src/processes/voteProcess.ts
+++ b/src/processes/voteProcess.ts
@@ -58,7 +58,11 @@ async function spawnBriefFromClosedVote(
   const factory = getProcessFactory();
   const brief = await factory({
     definition: { type: "civic.brief", version: "0.1" },
-    title: `Civic Brief: ${voteProcess.title}`,
+    // Title mirrors the vote's title. Contextual labels ("Civic Brief
+    // delivered: …" in the feed, "Civic Brief" eyebrow on the public page,
+    // "Civic Briefs" in the admin tab, etc.) handle disambiguation so the
+    // bare title doesn't need to repeat itself.
+    title: voteProcess.title,
     description: voteProcess.description,
     hubId: voteProcess.hubId,
     jurisdiction: voteProcess.jurisdiction,

--- a/src/routes/adminRoutes.ts
+++ b/src/routes/adminRoutes.ts
@@ -9,15 +9,28 @@ import {
   handleConvertProposal,
   handleArchiveProposal,
 } from "../controllers/adminController.js";
+import {
+  handleAdminListBriefs,
+  handleAdminGetBrief,
+  handlePatchBrief,
+  handleApproveBrief,
+} from "../controllers/adminBriefController.js";
 import { requireAdmin } from "../middleware/auth.js";
 
 const router = Router();
 
 router.use(requireAdmin);
 
+// Proposals
 router.get("/proposals", handleAdminListProposals);
 router.get("/proposals/:id", handleAdminGetProposal);
 router.post("/proposals/:id/convert", handleConvertProposal);
 router.post("/proposals/:id/archive", handleArchiveProposal);
+
+// Civic Briefs
+router.get("/briefs", handleAdminListBriefs);
+router.get("/briefs/:id", handleAdminGetBrief);
+router.patch("/briefs/:id", handlePatchBrief);
+router.post("/briefs/:id/approve", handleApproveBrief);
 
 export default router;

--- a/src/routes/adminRoutes.ts
+++ b/src/routes/adminRoutes.ts
@@ -15,6 +15,10 @@ import {
   handlePatchBrief,
   handleApproveBrief,
 } from "../controllers/adminBriefController.js";
+import {
+  handleGetSettings,
+  handlePatchSettings,
+} from "../controllers/adminSettingsController.js";
 import { requireAdmin } from "../middleware/auth.js";
 
 const router = Router();
@@ -32,5 +36,9 @@ router.get("/briefs", handleAdminListBriefs);
 router.get("/briefs/:id", handleAdminGetBrief);
 router.patch("/briefs/:id", handlePatchBrief);
 router.post("/briefs/:id/approve", handleApproveBrief);
+
+// Hub settings (admin-configurable; overrides env var fallbacks)
+router.get("/settings", handleGetSettings);
+router.patch("/settings", handlePatchSettings);
 
 export default router;

--- a/src/routes/briefRoutes.ts
+++ b/src/routes/briefRoutes.ts
@@ -1,0 +1,9 @@
+import { Router } from "express";
+import { handleGetBrief } from "../controllers/briefController.js";
+
+const router = Router();
+
+// Public — no auth required. Returns 404 for unpublished briefs.
+router.get("/:id", handleGetBrief);
+
+export default router;

--- a/src/services/hubSettings.ts
+++ b/src/services/hubSettings.ts
@@ -1,0 +1,98 @@
+// Hub settings service — read/write for the hub_settings key-value table.
+//
+// First consumer: brief recipient emails. The admin UI writes here, the
+// brief approval flow reads here first and falls back to the
+// BOARD_RECIPIENT_EMAIL env var if no row exists yet.
+//
+// Extendable: add more keys as other admin-configurable settings appear.
+
+import { getDb } from "../db/client.js";
+
+export const SETTING_KEYS = {
+  BRIEF_RECIPIENT_EMAILS: "brief_recipient_emails",
+} as const;
+
+export type SettingKey = (typeof SETTING_KEYS)[keyof typeof SETTING_KEYS];
+
+interface SettingRow {
+  key: string;
+  value: string;
+  updated_at: string;
+  updated_by: string | null;
+}
+
+export async function getSetting(key: string): Promise<string | null> {
+  const { data, error } = await getDb()
+    .from("hub_settings")
+    .select("value")
+    .eq("key", key)
+    .maybeSingle();
+  if (error) throw new Error(`hubSettings.get: ${error.message}`);
+  return (data as { value: string } | null)?.value ?? null;
+}
+
+export async function setSetting(
+  key: string,
+  value: string,
+  updatedBy: string | null,
+): Promise<void> {
+  const { error } = await getDb()
+    .from("hub_settings")
+    .upsert({ key, value, updated_by: updatedBy }, { onConflict: "key" });
+  if (error) throw new Error(`hubSettings.set: ${error.message}`);
+}
+
+export async function getAllSettings(): Promise<Record<string, SettingRow>> {
+  const { data, error } = await getDb()
+    .from("hub_settings")
+    .select("*");
+  if (error) throw new Error(`hubSettings.getAll: ${error.message}`);
+  const out: Record<string, SettingRow> = {};
+  for (const row of (data ?? []) as SettingRow[]) {
+    out[row.key] = row;
+  }
+  return out;
+}
+
+/**
+ * Resolve the brief recipient list — DB setting first, BOARD_RECIPIENT_EMAIL
+ * env var as a safety-net fallback. Returns a trimmed, deduped,
+ * non-empty list. Empty result means "no recipient configured anywhere".
+ */
+export async function getBriefRecipients(): Promise<string[]> {
+  const stored = await getSetting(SETTING_KEYS.BRIEF_RECIPIENT_EMAILS);
+  const raw = stored ?? process.env.BOARD_RECIPIENT_EMAIL ?? "";
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const part of raw.split(",")) {
+    const trimmed = part.trim();
+    if (!trimmed) continue;
+    const lower = trimmed.toLowerCase();
+    if (seen.has(lower)) continue;
+    seen.add(lower);
+    out.push(trimmed);
+  }
+  return out;
+}
+
+export async function setBriefRecipients(
+  emails: string[],
+  updatedBy: string | null,
+): Promise<string[]> {
+  const seen = new Set<string>();
+  const cleaned: string[] = [];
+  for (const raw of emails) {
+    const trimmed = typeof raw === "string" ? raw.trim() : "";
+    if (!trimmed) continue;
+    const lower = trimmed.toLowerCase();
+    if (seen.has(lower)) continue;
+    seen.add(lower);
+    cleaned.push(trimmed);
+  }
+  await setSetting(
+    SETTING_KEYS.BRIEF_RECIPIENT_EMAILS,
+    cleaned.join(","),
+    updatedBy,
+  );
+  return cleaned;
+}

--- a/src/services/mailer.ts
+++ b/src/services/mailer.ts
@@ -91,15 +91,3 @@ export async function sendEmail(message: EmailMessage): Promise<void> {
   }
 }
 
-/**
- * Parse comma-separated env var into a recipient list. Empty or missing
- * returns an empty array. Used for BOARD_RECIPIENT_EMAIL which may later
- * accept multiple addresses.
- */
-export function parseRecipients(raw: string | undefined): string[] {
-  if (!raw) return [];
-  return raw
-    .split(",")
-    .map((s) => s.trim())
-    .filter((s) => s.length > 0);
-}

--- a/src/services/mailer.ts
+++ b/src/services/mailer.ts
@@ -1,0 +1,105 @@
+// Mailer service — SMTP delivery with console fallback.
+//
+// Used by the admin brief approval flow (and any future hub feature that
+// needs to send email). Callers pass a fully-formatted message
+// (subject, html, text, recipients); this module handles transport.
+//
+// SMTP config comes from env vars:
+//   SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASS, SMTP_FROM
+//
+// If any of those are missing, we DO NOT throw — instead we log the
+// message to the console and treat delivery as successful. This keeps
+// local dev runnable without SMTP credentials and makes approval flows
+// testable end-to-end with a visible audit trail.
+
+import nodemailer, { Transporter } from "nodemailer";
+
+export interface EmailMessage {
+  to: string[];
+  subject: string;
+  html: string;
+  text: string;
+}
+
+let transporterSingleton: Transporter | null = null;
+
+function loadConfig(): {
+  host: string;
+  port: number;
+  user: string;
+  pass: string;
+  from: string;
+} | null {
+  const host = process.env.SMTP_HOST;
+  const portRaw = process.env.SMTP_PORT;
+  const user = process.env.SMTP_USER;
+  const pass = process.env.SMTP_PASS;
+  const from = process.env.SMTP_FROM;
+  if (!host || !portRaw || !user || !pass || !from) return null;
+  const port = Number.parseInt(portRaw, 10);
+  if (!Number.isFinite(port)) return null;
+  return { host, port, user, pass, from };
+}
+
+function getTransporter(): Transporter | null {
+  if (transporterSingleton) return transporterSingleton;
+  const cfg = loadConfig();
+  if (!cfg) return null;
+  transporterSingleton = nodemailer.createTransport({
+    host: cfg.host,
+    port: cfg.port,
+    secure: cfg.port === 465,
+    auth: { user: cfg.user, pass: cfg.pass },
+  });
+  return transporterSingleton;
+}
+
+/**
+ * Deliver an email. Falls back to console logging when SMTP is unconfigured.
+ * Throws on actual delivery failure so callers can halt on error.
+ */
+export async function sendEmail(message: EmailMessage): Promise<void> {
+  const cfg = loadConfig();
+  const transporter = getTransporter();
+
+  if (!cfg || !transporter) {
+    // Visible, structured fallback so local dev runs can see what would
+    // have been sent. Treated as success for flow purposes.
+    console.log("---- [mailer] SMTP unconfigured — logging email ----");
+    console.log(`To:      ${message.to.join(", ")}`);
+    console.log(`Subject: ${message.subject}`);
+    console.log("");
+    console.log(message.text);
+    console.log("---- [mailer] end email ----");
+    return;
+  }
+
+  try {
+    await transporter.sendMail({
+      from: cfg.from,
+      to: message.to,
+      subject: message.subject,
+      html: message.html,
+      text: message.text,
+    });
+    console.log(
+      `[mailer] delivered "${message.subject}" to ${message.to.length} recipient(s)`,
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "Unknown error";
+    throw new Error(`Email delivery failed: ${msg}`);
+  }
+}
+
+/**
+ * Parse comma-separated env var into a recipient list. Empty or missing
+ * returns an empty array. Used for BOARD_RECIPIENT_EMAIL which may later
+ * accept multiple addresses.
+ */
+export function parseRecipients(raw: string | undefined): string[] {
+  if (!raw) return [];
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}

--- a/src/services/processService.ts
+++ b/src/services/processService.ts
@@ -287,6 +287,34 @@ export async function getProcessState(
 // --- Dev/test utilities ----------------------------------------------------
 
 /** Clear all processes — dev/seed only. */
+/**
+ * Persist the current in-memory Process back to storage. Used by flows
+ * that mutate a process outside of the action dispatcher — for example,
+ * the admin brief approval orchestration, which mutates the brief and
+ * the linked vote directly via module functions (not HTTP actions).
+ *
+ * Updates status, state, and updated_at. Does NOT emit any events —
+ * callers that cause status transitions are responsible for emitting
+ * the corresponding lifecycle events themselves.
+ */
+export async function saveProcessState(process: Process): Promise<void> {
+  const now = new Date().toISOString();
+  const { error } = await getDb()
+    .from("processes")
+    .update({
+      status: process.status,
+      state: process.state,
+      updated_at: now,
+    })
+    .eq("id", process.id);
+  if (error) {
+    throw new Error(
+      `ProcessService: failed to save process ${process.id}: ${error.message}`,
+    );
+  }
+  process.updatedAt = now;
+}
+
 export async function clearProcesses(): Promise<void> {
   const { error } = await getDb().from("processes").delete().neq("id", "");
   if (error) {

--- a/src/utils/baseUrl.ts
+++ b/src/utils/baseUrl.ts
@@ -1,10 +1,38 @@
-// Shared helper for the hub's public base URL.
+// Shared helpers for the hub's public URLs.
 //
-// Strips any trailing slash so callers can safely do `${baseUrl()}/events`
-// without producing `https://host//events`. Defensive against env values
-// like "https://civic-hub-two.vercel.app/" (with trailing slash).
+// The hub distinguishes between two origins:
+//
+// - BASE_URL — the API origin. Used for `source.hub_url` (federation
+//   partners federate against this) and for `/.well-known/civic.json`
+//   discovery.
+// - CIVIC_UI_BASE_URL — the UI origin. Used for user-facing `action_url`
+//   values in events. Per Civic Event Spec §3, `action_url` is a "link to
+//   take action" — a human-reachable page, not a REST endpoint.
+//
+// In single-origin deployments (Vercel, where the UI is served from the
+// same host as the API), CIVIC_UI_BASE_URL can be unset and will fall
+// back to BASE_URL. In split-origin dev (API on :3000, UI on :5173), set
+// CIVIC_UI_BASE_URL=http://localhost:5173 so emitted events link to the
+// UI, not the JSON API.
+//
+// Both helpers strip trailing slashes so callers can do
+// `${baseUrl()}/events` without producing double slashes.
+
+function stripTrailingSlash(s: string): string {
+  return s.replace(/\/+$/, "");
+}
 
 export function baseUrl(): string {
   const raw = process.env.BASE_URL ?? "http://localhost:3000";
-  return raw.replace(/\/+$/, "");
+  return stripTrailingSlash(raw);
+}
+
+/**
+ * The origin from which UI pages are served. Used to construct `action_url`
+ * on events so citizens clicking through a feed post land on the UI, not
+ * on a JSON API response. Falls back to the API base when unset.
+ */
+export function uiBaseUrl(): string {
+  const raw = process.env.CIVIC_UI_BASE_URL ?? process.env.BASE_URL ?? "http://localhost:3000";
+  return stripTrailingSlash(raw);
 }

--- a/supabase/migrations/20260422000000_hub_settings.sql
+++ b/supabase/migrations/20260422000000_hub_settings.sql
@@ -1,0 +1,39 @@
+-- =====================================================================
+-- Migration 004 — hub_settings key-value table
+-- =====================================================================
+-- Generic key-value store for admin-configurable hub settings that shouldn't
+-- live in env vars because admins should be able to change them from the UI
+-- without a redeploy.
+--
+-- First use: brief_recipient_emails — the comma-separated list of addresses
+-- Civic Briefs are delivered to on admin approval. Falls back to the
+-- BOARD_RECIPIENT_EMAIL env var when the row doesn't exist yet, so existing
+-- deploys keep working without a manual insert.
+--
+-- Writes go through the backend service role only. RLS is on with no
+-- permissive policies, matching the project convention.
+-- =====================================================================
+
+CREATE TABLE hub_settings (
+  key        TEXT PRIMARY KEY,
+  value      TEXT NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_by TEXT
+);
+
+ALTER TABLE hub_settings ENABLE ROW LEVEL SECURITY;
+-- no permissive policies → service role only.
+
+-- Keep updated_at current on every row write.
+CREATE OR REPLACE FUNCTION hub_settings_touch_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at := NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER hub_settings_touch_updated_at
+  BEFORE INSERT OR UPDATE ON hub_settings
+  FOR EACH ROW
+  EXECUTE FUNCTION hub_settings_touch_updated_at();

--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -1785,6 +1785,48 @@
   opacity: 1;
 }
 
+/* --- Completed vote card with brief status --- */
+
+.completed-vote-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.completed-vote-brief-row {
+  display: flex;
+  justify-content: flex-end;
+  padding: 0 0.25rem;
+}
+
+.brief-link {
+  display: inline-block;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--color-brand, #1e3a5f);
+  text-decoration: none;
+  padding: 0.3rem 0.6rem;
+  border-radius: 4px;
+  transition: background 0.15s;
+}
+
+.brief-link:hover {
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.brief-pending-chip {
+  display: inline-block;
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--muted-text);
+  padding: 0.2rem 0.6rem;
+  background: var(--page-background);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  font-style: italic;
+}
+
 /* --- Utility --- */
 
 .error {

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -10,6 +10,8 @@ import About from "./pages/About";
 import Propose from "./pages/Propose";
 import ProposalDetail from "./pages/ProposalDetail";
 import AdminProposals from "./pages/AdminProposals";
+import AdminBriefs from "./pages/AdminBriefs";
+import Brief from "./pages/Brief";
 import VoteLog from "./pages/VoteLog";
 import IntroPopup, { hasSeenIntro } from "./components/IntroPopup";
 import "./App.css";
@@ -44,6 +46,8 @@ function AppContent() {
           <Route path="/proposal/:id" element={<ProposalDetail />} />
           <Route path="/votes/:id/log" element={<VoteLog />} />
           <Route path="/admin/proposals" element={<AdminProposals />} />
+          <Route path="/admin/briefs" element={<AdminBriefs />} />
+          <Route path="/brief/:id" element={<Brief />} />
           <Route path="/about" element={<About />} />
         </Routes>
       </main>

--- a/ui/src/components/AdminTabs.css
+++ b/ui/src/components/AdminTabs.css
@@ -1,0 +1,35 @@
+.admin-tabs {
+  display: flex;
+  gap: var(--space-lg);
+  align-items: center;
+  border-bottom: 1px solid var(--color-border);
+  margin: 0 0 var(--space-lg);
+  padding: 0 var(--space-lg);
+}
+
+.admin-tab {
+  display: inline-block;
+  padding: var(--space-sm) 0;
+  color: var(--color-text-muted);
+  text-decoration: none;
+  font-family: var(--font-body);
+  font-size: var(--font-size-base);
+  font-weight: 500;
+  border-bottom: 2px solid transparent;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.admin-tab:hover {
+  color: var(--color-text);
+}
+
+.admin-tab.is-active {
+  color: var(--color-text);
+  border-bottom-color: var(--color-primary);
+}
+
+.admin-tab:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}

--- a/ui/src/components/AdminTabs.tsx
+++ b/ui/src/components/AdminTabs.tsx
@@ -1,0 +1,27 @@
+import { NavLink } from "react-router-dom";
+import "./AdminTabs.css";
+
+/**
+ * Shared tab navigation for admin pages. Sits at the top of every admin
+ * surface (Proposals, Briefs, future: users/settings/etc) so the admin
+ * can jump between surfaces without leaving the admin context.
+ *
+ * Each tab is a NavLink so React Router assigns `aria-current="page"`
+ * automatically on the active tab.
+ */
+export default function AdminTabs() {
+  return (
+    <nav className="admin-tabs" aria-label="Admin sections">
+      <NavLink to="/admin/proposals" className={tabClass}>
+        Proposals
+      </NavLink>
+      <NavLink to="/admin/briefs" className={tabClass}>
+        Civic Briefs
+      </NavLink>
+    </nav>
+  );
+}
+
+function tabClass({ isActive }: { isActive: boolean }): string {
+  return `admin-tab${isActive ? " is-active" : ""}`;
+}

--- a/ui/src/components/Feed.tsx
+++ b/ui/src/components/Feed.tsx
@@ -4,6 +4,7 @@ import {
   type VoteState,
   getEvents,
   getProcessState,
+  getPublicBrief,
 } from "../services/api";
 import FeedPost, { eventToPost, type FeedPostView } from "./FeedPost";
 import "./Feed.css";
@@ -19,9 +20,28 @@ interface Props {
   filter?: (event: CivicEvent) => boolean;
 }
 
+type ProcessKind = "civic.vote" | "civic.brief";
+
 interface ProcessMeta {
+  type?: ProcessKind;
   title?: string;
   description?: string;
+}
+
+/**
+ * Discriminate the underlying process type for an event from its data.
+ * - civic.process.started is only emitted by civic.vote today.
+ * - civic.process.result_published carries `brief_id` on brief emissions
+ *   and `result` (with `tally`) on vote emissions.
+ */
+function kindFromEvent(event: CivicEvent): ProcessKind | null {
+  if (event.event_type === "civic.process.started") return "civic.vote";
+  if (event.event_type === "civic.process.result_published") {
+    const data = event.data as { brief_id?: unknown; result?: unknown };
+    if (typeof data?.brief_id === "string") return "civic.brief";
+    if (data?.result !== undefined) return "civic.vote";
+  }
+  return null;
 }
 
 export default function Feed({ filter }: Props) {
@@ -61,67 +81,70 @@ export default function Feed({ filter }: Props) {
     [renderableEvents, visibleCount],
   );
 
-  // Fetch process metadata lazily for events visible in the feed. Cached per
-  // process id so a second scroll past the same post does not refetch. The
-  // in-flight set uses a ref so StrictMode's effect double-invocation does
-  // not double-fire requests or cancel the first run's fetches.
+  // Fetch per-process metadata lazily for events visible in the feed. The
+  // in-flight set is a ref so StrictMode's double-invoke doesn't double-fire
+  // or cancel requests.
   const inFlight = useRef<Set<string>>(new Set());
   useEffect(() => {
-    const needed: string[] = [];
+    const needed: Array<{ id: string; kind: ProcessKind }> = [];
     for (const ev of visibleEvents) {
-      if (
-        (ev.event_type === "civic.process.started" ||
-          ev.event_type === "civic.process.result_published") &&
-        ev.process_id &&
-        !(ev.process_id in processMeta) &&
-        !inFlight.current.has(ev.process_id)
-      ) {
-        needed.push(ev.process_id);
-      }
+      const kind = kindFromEvent(ev);
+      if (!kind) continue;
+      if (!ev.process_id) continue;
+      if (ev.process_id in processMeta) continue;
+      if (inFlight.current.has(ev.process_id)) continue;
+      needed.push({ id: ev.process_id, kind });
     }
     if (needed.length === 0) return;
 
-    for (const id of needed) inFlight.current.add(id);
+    for (const { id } of needed) inFlight.current.add(id);
 
-    needed.forEach((id) => {
-      getProcessState(id)
-        .then((state) => {
-          if (state.type !== "civic.vote") {
+    for (const { id, kind } of needed) {
+      const lookup =
+        kind === "civic.vote"
+          ? getProcessState(id).then((state) => {
+              if (state.type !== "civic.vote") return null;
+              const vote = state as VoteState;
+              return { type: "civic.vote" as const, title: vote.title, description: vote.description };
+            })
+          : getPublicBrief(id).then((brief) => ({
+              type: "civic.brief" as const,
+              title: brief.title,
+              description: undefined,
+            }));
+
+      lookup
+        .then((meta) => {
+          if (meta) {
+            setProcessMeta((prev) => ({ ...prev, [id]: meta }));
+          } else {
+            // Mark resolved-but-empty so we don't retry every re-render.
             setProcessMeta((prev) => ({ ...prev, [id]: {} }));
-            return;
           }
-          const vote = state as VoteState;
-          setProcessMeta((prev) => ({
-            ...prev,
-            [id]: { title: vote.title, description: vote.description },
-          }));
         })
         .catch(() => {
-          // Best-effort enrichment — mark resolved so we don't retry on every
-          // re-render, and render the post without a summary.
+          // Most commonly: brief not yet published (404). Cache as empty so
+          // the post either skips rendering or shows a fallback title.
           setProcessMeta((prev) => ({ ...prev, [id]: {} }));
         })
         .finally(() => {
           inFlight.current.delete(id);
         });
-    });
+    }
   }, [visibleEvents, processMeta]);
 
   const posts: FeedPostView[] = useMemo(() => {
     const getTitle = (id: string) => processMeta[id]?.title;
     const getDescription = (id: string) => processMeta[id]?.description;
+    const getType = (id: string) => processMeta[id]?.type;
     const out: FeedPostView[] = [];
     for (const ev of visibleEvents) {
-      const post = eventToPost(ev, getDescription, getTitle);
+      const post = eventToPost(ev, getDescription, getTitle, getType);
       if (post) out.push(post);
     }
     return out;
   }, [visibleEvents, processMeta]);
 
-  // Determine if more renderable (filtered) events exist beyond the current
-  // page. We can't know which of the *unloaded* events will pass the post
-  // filter without inspecting them — they're already loaded in `events`, so
-  // we just compare counts of the filtered list.
   const hasMore = renderableEvents.length > visibleCount;
 
   if (loading) {

--- a/ui/src/components/FeedPost.tsx
+++ b/ui/src/components/FeedPost.tsx
@@ -29,14 +29,14 @@ export function eventToPost(
   event: CivicEvent,
   getProcessDescription: (processId: string) => string | undefined,
   getProcessTitle: (processId: string) => string | undefined,
+  getProcessType: (processId: string) => "civic.vote" | "civic.brief" | undefined,
 ): FeedPostView | null {
   switch (event.event_type) {
     case "civic.process.started": {
-      // `started` fires when the process enters active participation. Today
-      // civic.vote is the only process type that emits this event, so we
-      // render it as a "New vote: …" post. When additional process types
-      // start emitting `started` (petitions, announcements, etc.), branch
-      // here by the cached process type.
+      // `started` fires when a process enters active participation. Today
+      // only civic.vote emits this event; render as "New vote: …". When
+      // additional process types start emitting `started` (petitions,
+      // announcements, etc.), branch here by the cached process type.
       const title = getProcessTitle(event.process_id) ?? "Untitled vote";
       return {
         id: event.id,
@@ -48,15 +48,44 @@ export function eventToPost(
     }
 
     case "civic.process.result_published": {
-      const result = (event.data as {
-        result?: { tally?: Record<string, number>; total_votes?: number };
-      }).result;
-      const total = result?.total_votes ?? 0;
-      const title = getProcessTitle(event.process_id) ?? `Process ${event.process_id}`;
+      // Discriminate vote vs brief. Vote results publish "Vote results
+      // published: [title]"; briefs publish "Civic Brief delivered: [title]"
+      // and link to the public /brief/:id page. Briefs' action_url already
+      // points at /brief/:id via the backend's action_url_path override.
+      const data = event.data as {
+        brief_id?: string;
+        result?: { total_votes?: number };
+        participation_count?: number;
+        headline_result?: string;
+      };
+
+      const isBrief =
+        typeof data.brief_id === "string" ||
+        getProcessType(event.process_id) === "civic.brief";
+
+      if (isBrief) {
+        const title = getProcessTitle(event.process_id) ?? "Civic Brief";
+        const count = data.participation_count ?? 0;
+        const noun = count === 1 ? "resident" : "residents";
+        const summary = data.headline_result
+          ? `${count} ${noun} — ${data.headline_result}`
+          : `${count} ${noun} participated — brief delivered to the Board.`;
+        return {
+          id: event.id,
+          title: `Civic Brief delivered: ${title}`,
+          summary,
+          timestamp: event.timestamp,
+          href: event.action_url,
+        };
+      }
+
+      const total = data.result?.total_votes ?? 0;
+      const title =
+        getProcessTitle(event.process_id) ?? `Process ${event.process_id}`;
       const noun = total === 1 ? "participant" : "participants";
       return {
         id: event.id,
-        title: `Results available: ${title}`,
+        title: `Vote results published: ${title}`,
         summary: `${total} ${noun} — results now public.`,
         timestamp: event.timestamp,
         href: event.action_url,
@@ -122,7 +151,13 @@ function absoluteTime(iso: string): string {
 function classifyHref(href: string): { kind: "internal"; to: string } | { kind: "external" } {
   try {
     const url = new URL(href, window.location.origin);
+    // Known SPA routes — treat as internal regardless of origin so the
+    // dev cross-port mismatch (API on 3000, UI on 5173) and single-origin
+    // prod both route via React Router.
     if (/^\/process\/[^/]+\/?$/.test(url.pathname)) {
+      return { kind: "internal", to: url.pathname };
+    }
+    if (/^\/brief\/[^/]+\/?$/.test(url.pathname)) {
       return { kind: "internal", to: url.pathname };
     }
     if (url.origin === window.location.origin) {

--- a/ui/src/pages/AdminBriefs.css
+++ b/ui/src/pages/AdminBriefs.css
@@ -1,0 +1,86 @@
+.admin-briefs-page {
+  padding: 0;
+}
+
+.admin-briefs-body {
+  padding: var(--space-md) var(--space-lg) var(--space-xl);
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.admin-briefs-body h1 {
+  margin: 0 0 var(--space-xs);
+}
+
+.admin-brief-filters {
+  display: flex;
+  gap: var(--space-sm);
+  margin: var(--space-md) 0 var(--space-lg);
+  flex-wrap: wrap;
+}
+
+.admin-brief-filter {
+  padding: var(--space-xs) var(--space-md);
+  background: var(--color-surface);
+  color: var(--color-text-muted);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-body);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s, background 0.15s;
+}
+
+.admin-brief-filter:hover {
+  color: var(--color-text);
+  border-color: var(--color-border-hover);
+}
+
+.admin-brief-filter.is-active {
+  color: var(--color-primary-text);
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+}
+
+.admin-brief-filter:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
+}
+
+.admin-back-link {
+  display: inline-block;
+  background: none;
+  border: none;
+  padding: 0;
+  margin-bottom: var(--space-md);
+  color: var(--color-text-muted);
+  font-family: var(--font-body);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+}
+
+.admin-back-link:hover {
+  color: var(--color-text);
+}
+
+.brief-positions-list {
+  margin: 0;
+  padding-left: 1.25rem;
+  line-height: 1.6;
+}
+
+/* --- Publication status chips (new; complements App.css status chips) --- */
+.admin-brief-status-pending {
+  background: #fff3e0;
+  color: #e65100;
+}
+
+.admin-brief-status-approved {
+  background: #e8eaf6;
+  color: #283593;
+}
+
+.admin-brief-status-published {
+  background: var(--success-bg, #e8f5e9);
+  color: var(--success-color, #2e7d32);
+}

--- a/ui/src/pages/AdminBriefs.css
+++ b/ui/src/pages/AdminBriefs.css
@@ -12,6 +12,38 @@
   margin: 0 0 var(--space-xs);
 }
 
+.admin-settings-panel {
+  margin: var(--space-md) 0 var(--space-lg);
+  padding: var(--space-md) var(--space-lg);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+}
+
+.admin-settings-panel h3 {
+  margin: 0 0 var(--space-sm);
+  font-family: var(--font-heading);
+  font-size: var(--font-size-base);
+  color: var(--color-brand);
+}
+
+.admin-settings-panel .form-hint {
+  margin: 0 0 var(--space-sm);
+}
+
+.admin-settings-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+  margin-top: var(--space-sm);
+  flex-wrap: wrap;
+}
+
+.admin-settings-message {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
 .admin-brief-filters {
   display: flex;
   gap: var(--space-sm);

--- a/ui/src/pages/AdminBriefs.tsx
+++ b/ui/src/pages/AdminBriefs.tsx
@@ -1,0 +1,339 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  adminListBriefs,
+  adminGetBrief,
+  adminPatchBrief,
+  adminApproveBrief,
+  type BriefDetail,
+  type BriefPublicationStatus,
+  type BriefSummary,
+} from "../services/api";
+import AdminTabs from "../components/AdminTabs";
+import "./AdminBriefs.css";
+
+type View = "list" | "review";
+
+const STATUS_FILTERS: Array<{ id: "all" | BriefPublicationStatus; label: string }> = [
+  { id: "all", label: "All" },
+  { id: "pending", label: "Pending" },
+  { id: "approved", label: "Approved" },
+  { id: "published", label: "Published" },
+];
+
+export default function AdminBriefs() {
+  const [view, setView] = useState<View>("list");
+  const [briefs, setBriefs] = useState<BriefSummary[]>([]);
+  const [selected, setSelected] = useState<BriefDetail | null>(null);
+  const [statusFilter, setStatusFilter] = useState<"all" | BriefPublicationStatus>("all");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [actionMessage, setActionMessage] = useState<string | null>(null);
+
+  // Review form state
+  const [commentsText, setCommentsText] = useState("");
+  const [adminNotes, setAdminNotes] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [approving, setApproving] = useState(false);
+  const [confirmingApprove, setConfirmingApprove] = useState(false);
+
+  function loadList() {
+    setLoading(true);
+    setError(null);
+    adminListBriefs()
+      .then(setBriefs)
+      .catch((err) => setError(err.message))
+      .finally(() => setLoading(false));
+  }
+
+  useEffect(() => {
+    loadList();
+  }, []);
+
+  const filtered = useMemo(() => {
+    if (statusFilter === "all") return briefs;
+    return briefs.filter((b) => b.publication_status === statusFilter);
+  }, [briefs, statusFilter]);
+
+  function openReview(id: string) {
+    setError(null);
+    setActionMessage(null);
+    adminGetBrief(id)
+      .then((brief) => {
+        setSelected(brief);
+        setCommentsText(brief.content.comments.join("\n"));
+        setAdminNotes(brief.content.admin_notes);
+        setView("review");
+        setConfirmingApprove(false);
+      })
+      .catch((err) => setError(err.message));
+  }
+
+  function backToList() {
+    setSelected(null);
+    setView("list");
+    setConfirmingApprove(false);
+    setActionMessage(null);
+    setError(null);
+    loadList();
+  }
+
+  async function saveDraft() {
+    if (!selected) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const updated = await adminPatchBrief(selected.id, {
+        comments: parseCommentsText(commentsText),
+        admin_notes: adminNotes,
+      });
+      setSelected(updated);
+      setActionMessage("Draft saved.");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function approve() {
+    if (!selected) return;
+    setApproving(true);
+    setError(null);
+    try {
+      // Save any unsaved edits first so the published brief matches what the
+      // admin is looking at.
+      await adminPatchBrief(selected.id, {
+        comments: parseCommentsText(commentsText),
+        admin_notes: adminNotes,
+      });
+      const { brief } = await adminApproveBrief(selected.id);
+      setSelected(brief);
+      setActionMessage(
+        `Approved. Brief delivered to ${brief.delivered_to.length} recipient(s) and published to the feed.`,
+      );
+      setConfirmingApprove(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to approve");
+    } finally {
+      setApproving(false);
+    }
+  }
+
+  if (view === "review" && selected) {
+    const isPending = selected.publication_status === "pending";
+    return (
+      <div className="page admin-briefs-page">
+        <AdminTabs />
+        <div className="admin-briefs-body">
+          <button className="admin-back-link" onClick={backToList} type="button">
+            &larr; Back to Civic Briefs
+          </button>
+          <h1>Review: {selected.title}</h1>
+          <p className="admin-subtitle">
+            Status: <StatusChip status={selected.publication_status} /> · Generated{" "}
+            {formatDateTime(selected.generated_at)}
+          </p>
+
+          {actionMessage && <p className="admin-action-message">{actionMessage}</p>}
+          {error && <p className="form-error">{error}</p>}
+
+          <section className="admin-detail-section">
+            <h3>Participation</h3>
+            <p>
+              {selected.content.participation_count} resident
+              {selected.content.participation_count === 1 ? "" : "s"} voted.
+            </p>
+          </section>
+
+          <section className="admin-detail-section">
+            <h3>Positions</h3>
+            <ul className="brief-positions-list">
+              {selected.content.position_breakdown.map((p) => (
+                <li key={p.option_id}>
+                  <strong>{p.option_label}:</strong> {p.count} ({p.percentage}%)
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          <section className="admin-detail-section">
+            <h3>Community comments</h3>
+            <p className="form-hint">
+              One comment per line. Empty lines are ignored; duplicates are
+              removed. This field will be pre-populated from civic.input in a
+              future slice — for now, add anything worth surfacing to the Board.
+            </p>
+            <textarea
+              className="form-textarea"
+              rows={6}
+              value={commentsText}
+              onChange={(e) => setCommentsText(e.target.value)}
+              disabled={!isPending}
+              placeholder="(none)"
+            />
+          </section>
+
+          <section className="admin-detail-section">
+            <h3>Notes from the Civic Hub</h3>
+            <p className="form-hint">
+              Optional admin-authored context delivered alongside the results.
+            </p>
+            <textarea
+              className="form-textarea"
+              rows={4}
+              value={adminNotes}
+              onChange={(e) => setAdminNotes(e.target.value)}
+              disabled={!isPending}
+              placeholder="(none)"
+            />
+          </section>
+
+          {selected.delivered_to.length > 0 && (
+            <section className="admin-detail-section">
+              <h3>Delivered to</h3>
+              <ul>
+                {selected.delivered_to.map((r) => (
+                  <li key={r}>{r}</li>
+                ))}
+              </ul>
+            </section>
+          )}
+
+          {isPending && (
+            <div className="admin-actions">
+              <button
+                type="button"
+                className="admin-archive-button"
+                onClick={saveDraft}
+                disabled={saving || approving}
+              >
+                {saving ? "Saving…" : "Save draft"}
+              </button>
+              {confirmingApprove ? (
+                <>
+                  <button
+                    type="button"
+                    className="admin-convert-button"
+                    onClick={approve}
+                    disabled={approving}
+                  >
+                    {approving ? "Approving…" : "Confirm: approve and publish"}
+                  </button>
+                  <button
+                    type="button"
+                    className="admin-cancel-button"
+                    onClick={() => setConfirmingApprove(false)}
+                    disabled={approving}
+                  >
+                    Cancel
+                  </button>
+                </>
+              ) : (
+                <button
+                  type="button"
+                  className="admin-convert-button"
+                  onClick={() => setConfirmingApprove(true)}
+                  disabled={saving}
+                >
+                  Approve and publish
+                </button>
+              )}
+            </div>
+          )}
+          {confirmingApprove && (
+            <p className="form-hint" style={{ marginTop: "var(--space-sm)" }}>
+              This will deliver the brief to the Board and publish a "Civic Brief
+              delivered" post to the public feed. This cannot be undone.
+            </p>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="page admin-briefs-page">
+      <AdminTabs />
+      <div className="admin-briefs-body">
+        <h1>Civic Briefs</h1>
+        <p className="admin-subtitle">
+          Review briefs generated automatically when votes close. Approval delivers
+          the brief to the Board of Supervisors and publishes it to the public feed.
+        </p>
+
+        <div className="admin-brief-filters">
+          {STATUS_FILTERS.map((f) => (
+            <button
+              key={f.id}
+              type="button"
+              className={`admin-brief-filter${statusFilter === f.id ? " is-active" : ""}`}
+              onClick={() => setStatusFilter(f.id)}
+            >
+              {f.label}
+            </button>
+          ))}
+        </div>
+
+        {loading && <p>Loading…</p>}
+        {error && <p className="form-error">{error}</p>}
+
+        {!loading && !error && filtered.length === 0 && (
+          <p className="empty-state-inline">
+            {statusFilter === "all"
+              ? "No briefs yet. Briefs are created automatically when votes close."
+              : `No ${statusFilter} briefs.`}
+          </p>
+        )}
+
+        <ul className="admin-proposal-list">
+          {filtered.map((brief) => (
+            <li
+              key={brief.id}
+              className="admin-proposal-item"
+              onClick={() => openReview(brief.id)}
+            >
+              <div className="admin-proposal-header">
+                <h3>{brief.title}</h3>
+                <StatusChip status={brief.publication_status} />
+              </div>
+              <div className="admin-proposal-meta">
+                <span>{brief.participation_count} votes</span>
+                <span>Generated {formatDate(brief.generated_at)}</span>
+                {brief.published_at && (
+                  <span>Published {formatDate(brief.published_at)}</span>
+                )}
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+function StatusChip({ status }: { status: BriefPublicationStatus }) {
+  const cls = `status-badge admin-brief-status-${status}`;
+  const label =
+    status === "pending" ? "pending review" : status === "approved" ? "approved" : "published";
+  return <span className={cls}>{label}</span>;
+}
+
+function parseCommentsText(text: string): string[] {
+  return text
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function formatDateTime(iso: string): string {
+  const d = new Date(iso);
+  return `${d.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" })} at ${d.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" })}`;
+}

--- a/ui/src/pages/AdminBriefs.tsx
+++ b/ui/src/pages/AdminBriefs.tsx
@@ -4,6 +4,8 @@ import {
   adminGetBrief,
   adminPatchBrief,
   adminApproveBrief,
+  adminGetSettings,
+  adminPatchSettings,
   type BriefDetail,
   type BriefPublicationStatus,
   type BriefSummary,
@@ -35,6 +37,47 @@ export default function AdminBriefs() {
   const [saving, setSaving] = useState(false);
   const [approving, setApproving] = useState(false);
   const [confirmingApprove, setConfirmingApprove] = useState(false);
+
+  // Settings (recipient email list)
+  const [recipientsText, setRecipientsText] = useState("");
+  const [recipientsLoaded, setRecipientsLoaded] = useState(false);
+  const [savingRecipients, setSavingRecipients] = useState(false);
+  const [recipientsMessage, setRecipientsMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    adminGetSettings()
+      .then((s) => {
+        setRecipientsText(s.brief_recipient_emails.join(", "));
+        setRecipientsLoaded(true);
+      })
+      .catch((err: Error) => {
+        setError(`Could not load settings: ${err.message}`);
+      });
+  }, []);
+
+  async function saveRecipients() {
+    setSavingRecipients(true);
+    setRecipientsMessage(null);
+    try {
+      const input = recipientsText
+        .split(/[,\n]/)
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0);
+      const saved = await adminPatchSettings({ brief_recipient_emails: input });
+      setRecipientsText(saved.brief_recipient_emails.join(", "));
+      setRecipientsMessage(
+        saved.brief_recipient_emails.length === 0
+          ? "Cleared — approvals will be blocked until a recipient is set."
+          : `Saved. Briefs will be delivered to ${saved.brief_recipient_emails.length} recipient(s).`,
+      );
+    } catch (err) {
+      setRecipientsMessage(
+        err instanceof Error ? err.message : "Failed to save recipients",
+      );
+    } finally {
+      setSavingRecipients(false);
+    }
+  }
 
   function loadList() {
     setLoading(true);
@@ -260,6 +303,39 @@ export default function AdminBriefs() {
           Review briefs generated automatically when votes close. Approval delivers
           the brief to the Board of Supervisors and publishes it to the public feed.
         </p>
+
+        <section className="admin-settings-panel">
+          <h3>Delivery settings</h3>
+          <label className="form-label" htmlFor="brief-recipients">
+            Brief recipient emails
+          </label>
+          <p className="form-hint">
+            Comma- or newline-separated list of addresses that receive the brief
+            on approval. Changes take effect on the next approval.
+          </p>
+          <textarea
+            id="brief-recipients"
+            className="form-textarea"
+            rows={2}
+            value={recipientsText}
+            onChange={(e) => setRecipientsText(e.target.value)}
+            disabled={!recipientsLoaded || savingRecipients}
+            placeholder="board@floyd.gov, clerk@floyd.gov"
+          />
+          <div className="admin-settings-actions">
+            <button
+              type="button"
+              className="admin-convert-button"
+              onClick={saveRecipients}
+              disabled={!recipientsLoaded || savingRecipients}
+            >
+              {savingRecipients ? "Saving…" : "Save recipients"}
+            </button>
+            {recipientsMessage && (
+              <span className="admin-settings-message">{recipientsMessage}</span>
+            )}
+          </div>
+        </section>
 
         <div className="admin-brief-filters">
           {STATUS_FILTERS.map((f) => (

--- a/ui/src/pages/AdminProposals.tsx
+++ b/ui/src/pages/AdminProposals.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
 import {
   adminListProposals,
   adminGetProposal,
@@ -10,6 +9,7 @@ import {
   type ContentSection,
   type ContentLink,
 } from "../services/api";
+import AdminTabs from "../components/AdminTabs";
 
 const ADMIN_USER = "user:civic-admin";
 
@@ -182,7 +182,7 @@ export default function AdminProposals() {
   if (view === "list") {
     return (
       <div className="page detail-page admin-page">
-        <Link to="/" className="back-link">&larr; Home</Link>
+        <AdminTabs />
         <h1>Admin: Proposal Review</h1>
         <p className="admin-subtitle">
           Endorsed proposals need review. Convert them to official votes or archive them.

--- a/ui/src/pages/Brief.css
+++ b/ui/src/pages/Brief.css
@@ -1,0 +1,117 @@
+.brief-page {
+  padding: var(--space-lg);
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+.brief-status {
+  color: var(--color-text-subtle);
+  font-family: var(--font-body);
+  font-size: var(--font-size-base);
+  text-align: center;
+  padding: var(--space-xl) var(--space-md);
+}
+
+.brief-status-error {
+  color: var(--color-text);
+}
+
+.brief-header {
+  margin: 0 0 var(--space-xl);
+}
+
+.brief-eyebrow {
+  margin: 0;
+  color: var(--color-brand);
+  font-family: var(--font-heading);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.brief-header h1 {
+  margin: var(--space-xs) 0 var(--space-sm);
+  font-size: var(--font-size-xl);
+  line-height: var(--line-height-tight);
+}
+
+.brief-meta {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-base);
+}
+
+.brief-section {
+  margin: 0 0 var(--space-xl);
+}
+
+.brief-section h2 {
+  font-family: var(--font-heading);
+  font-size: var(--font-size-lg);
+  margin: 0 0 var(--space-md);
+  color: var(--color-text);
+}
+
+.brief-bars {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.brief-bar-row {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.brief-bar-label {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: var(--space-md);
+  font-size: var(--font-size-base);
+}
+
+.brief-bar-count {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  white-space: nowrap;
+}
+
+.brief-bar-track {
+  height: 12px;
+  background: var(--color-surface-muted);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+
+.brief-bar-fill {
+  height: 100%;
+  background: var(--color-primary);
+  border-radius: var(--radius-sm);
+  transition: width 0.3s ease;
+  min-width: 2px;
+}
+
+.brief-comments-list {
+  padding-left: 1.25rem;
+  margin: 0;
+  line-height: var(--line-height-base);
+  color: var(--color-text);
+}
+
+.brief-comments-list li {
+  margin-bottom: var(--space-xs);
+}
+
+.brief-admin-notes {
+  margin: 0;
+  color: var(--color-text);
+  line-height: var(--line-height-base);
+  white-space: pre-wrap;
+}

--- a/ui/src/pages/Brief.tsx
+++ b/ui/src/pages/Brief.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import { getPublicBrief, type PublicBrief } from "../services/api";
+import "./Brief.css";
+
+export default function BriefPage() {
+  const { id } = useParams<{ id: string }>();
+  const [brief, setBrief] = useState<PublicBrief | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!id) return;
+    let cancelled = false;
+    setLoading(true);
+    getPublicBrief(id)
+      .then((b) => {
+        if (cancelled) return;
+        setBrief(b);
+      })
+      .catch((err: Error) => {
+        if (cancelled) return;
+        setError(err.message);
+      })
+      .finally(() => {
+        if (cancelled) return;
+        setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+
+  if (loading) {
+    return (
+      <div className="page brief-page">
+        <p className="brief-status">Loading brief…</p>
+      </div>
+    );
+  }
+
+  if (error || !brief) {
+    return (
+      <div className="page brief-page">
+        <Link to="/" className="back-link">
+          &larr; Home
+        </Link>
+        <p className="brief-status brief-status-error">
+          {error ?? "Brief not found."}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <article className="page brief-page">
+      <Link to="/" className="back-link">
+        &larr; Home
+      </Link>
+      <header className="brief-header">
+        <p className="brief-eyebrow">Civic Brief</p>
+        <h1>{brief.title}</h1>
+        <p className="brief-meta">
+          Published{" "}
+          <time dateTime={brief.published_at}>
+            {formatDate(brief.published_at)}
+          </time>{" "}
+          · {brief.participation_count} resident
+          {brief.participation_count === 1 ? "" : "s"} participated ·{" "}
+          <Link to={`/process/${brief.source_process_id}`} className="inline-link">
+            view vote
+          </Link>
+        </p>
+      </header>
+
+      <section className="brief-section">
+        <h2>Positions</h2>
+        <ul className="brief-bars">
+          {brief.position_breakdown.map((p) => (
+            <li key={p.option_id} className="brief-bar-row">
+              <div className="brief-bar-label">
+                <span>{p.option_label}</span>
+                <span className="brief-bar-count">
+                  {p.count} ({p.percentage}%)
+                </span>
+              </div>
+              <div className="brief-bar-track">
+                <div
+                  className="brief-bar-fill"
+                  style={{ width: `${Math.min(p.percentage, 100)}%` }}
+                />
+              </div>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      {brief.comments.length > 0 && (
+        <section className="brief-section">
+          <h2>Community comments</h2>
+          <ul className="brief-comments-list">
+            {brief.comments.map((c, i) => (
+              <li key={i}>{c}</li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {brief.admin_notes.trim().length > 0 && (
+        <section className="brief-section">
+          <h2>Notes from the Civic Hub</h2>
+          <p className="brief-admin-notes">{brief.admin_notes}</p>
+        </section>
+      )}
+    </article>
+  );
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}

--- a/ui/src/pages/Votes.tsx
+++ b/ui/src/pages/Votes.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import {
   listProcesses,
   listCivicProposals,
   type ProcessSummary,
+  type PublishedBriefSummary,
   type VoteSummary,
   type ProposalSummary,
   type CivicProposalSummary,
@@ -31,13 +32,33 @@ export default function Votes() {
       .finally(() => setLoading(false));
   }, []);
 
-  // Active and completed votes (active, closed, finalized)
+  // Active votes — accepting participation right now.
   const activeVotes = processes
     .filter((p): p is VoteSummary =>
-      p.type === "civic.vote" &&
-      (p.status === "active" || p.status === "closed" || p.status === "finalized")
+      p.type === "civic.vote" && p.status === "active"
     )
     .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
+
+  // Completed votes — closed or finalized. A brief may or may not be
+  // published against them; the chip tells the story either way.
+  const completedVotes = processes
+    .filter((p): p is VoteSummary =>
+      p.type === "civic.vote" &&
+      (p.status === "closed" || p.status === "finalized")
+    )
+    .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
+
+  // Index published briefs by source vote id so completed-vote cards can
+  // link to their brief in one lookup.
+  const briefsByVote = useMemo(() => {
+    const map = new Map<string, PublishedBriefSummary>();
+    for (const p of processes) {
+      if (p.type === "civic.brief") {
+        map.set(p.source_process_id, p);
+      }
+    }
+    return map;
+  }, [processes]);
 
   // Votes in proposal phase (proposed, threshold_met, draft)
   const proposedVotes = processes
@@ -89,7 +110,7 @@ export default function Votes() {
             )}
           </section>
 
-          {/* Proposed Votes — single unified section */}
+          {/* Proposed Votes */}
           <section className="section">
             <div className="section-header-row">
               <h2 className="section-title">Proposed Votes</h2>
@@ -105,7 +126,6 @@ export default function Votes() {
               </p>
             ) : (
               <ul className="process-list">
-                {/* Vote-lifecycle proposals (civic.vote in proposed/threshold_met/draft) */}
                 {proposedVotes.map((v) => (
                   <li key={v.id}>
                     <Link to={`/process/${v.id}`} className="process-link">
@@ -114,7 +134,6 @@ export default function Votes() {
                   </li>
                 ))}
 
-                {/* Legacy proposals (civic.proposal type) */}
                 {legacyProposals.map((p) => (
                   <li key={p.id}>
                     <Link to={`/process/${p.id}`} className="process-link">
@@ -123,7 +142,6 @@ export default function Votes() {
                   </li>
                 ))}
 
-                {/* Civic proposals (user-submitted via /proposals) */}
                 {activeCivicProposals.map((p) => (
                   <li key={p.id}>
                     <Link to={`/proposal/${p.id}`} className="process-link">
@@ -155,6 +173,40 @@ export default function Votes() {
                     </Link>
                   </li>
                 ))}
+              </ul>
+            )}
+          </section>
+
+          {/* Completed Votes */}
+          <section className="section">
+            <h2 className="section-title">Completed Votes</h2>
+            {completedVotes.length === 0 ? (
+              <p className="empty-state-inline">No completed votes yet.</p>
+            ) : (
+              <ul className="process-list">
+                {completedVotes.map((v) => {
+                  const brief = briefsByVote.get(v.id);
+                  return (
+                    <li key={v.id}>
+                      <div className="completed-vote-card">
+                        <Link to={`/process/${v.id}`} className="process-link">
+                          <ProcessCard process={v} />
+                        </Link>
+                        <div className="completed-vote-brief-row">
+                          {brief ? (
+                            <Link to={`/brief/${brief.id}`} className="brief-link">
+                              View Civic Brief &rarr;
+                            </Link>
+                          ) : (
+                            <span className="brief-pending-chip">
+                              Civic Brief pending review
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                    </li>
+                  );
+                })}
               </ul>
             )}
           </section>

--- a/ui/src/services/api.ts
+++ b/ui/src/services/api.ts
@@ -111,7 +111,23 @@ export interface ProposalSummary extends ProcessSummaryBase {
   support_threshold: number;
 }
 
-export type ProcessSummary = VoteSummary | ProposalSummary;
+/** Civic brief summary as it appears in the public process list. The
+ *  public listProcesses endpoint only returns briefs with
+ *  publication_status === "published"; pending/approved briefs are
+ *  filtered out server-side. */
+export interface PublishedBriefSummary {
+  id: string;
+  type: "civic.brief";
+  title: string;
+  source_process_id: string;
+  publication_status: "published";
+  participation_count: number;
+  generated_at: string;
+  published_at: string;
+  created_at: string;
+}
+
+export type ProcessSummary = VoteSummary | ProposalSummary | PublishedBriefSummary;
 
 /** Vote detail state */
 export interface VoteState {
@@ -417,4 +433,84 @@ interface EventsResponse {
 export async function getEvents(): Promise<CivicEvent[]> {
   const res = await request<EventsResponse>("GET", "/events");
   return res.events;
+}
+
+// --- Civic Briefs ---
+
+export type BriefPublicationStatus = "pending" | "approved" | "published";
+
+export interface BriefPositionBreakdown {
+  option_id: string;
+  option_label: string;
+  count: number;
+  percentage: number;
+}
+
+export interface BriefContent {
+  title: string;
+  participation_count: number;
+  position_breakdown: BriefPositionBreakdown[];
+  comments: string[];
+  admin_notes: string;
+}
+
+/** Admin list summary */
+export interface BriefSummary {
+  id: string;
+  type: "civic.brief";
+  title: string;
+  source_process_id: string;
+  publication_status: BriefPublicationStatus;
+  participation_count: number;
+  generated_at: string;
+  approved_at: string | null;
+  published_at: string | null;
+  created_at: string;
+}
+
+/** Admin detail (full brief including editable content) */
+export interface BriefDetail extends BriefSummary {
+  content: BriefContent;
+  delivered_to: string[];
+  created_by: string;
+}
+
+/** Public brief — returned only when publication_status === "published" */
+export interface PublicBrief {
+  id: string;
+  type: "civic.brief";
+  title: string;
+  source_process_id: string;
+  participation_count: number;
+  position_breakdown: BriefPositionBreakdown[];
+  comments: string[];
+  admin_notes: string;
+  generated_at: string;
+  published_at: string;
+}
+
+export interface BriefContentPatch {
+  comments?: string[];
+  admin_notes?: string;
+}
+
+export function adminListBriefs(status?: BriefPublicationStatus): Promise<BriefSummary[]> {
+  const params = status ? `?status=${encodeURIComponent(status)}` : "";
+  return request("GET", `/admin/briefs${params}`);
+}
+
+export function adminGetBrief(id: string): Promise<BriefDetail> {
+  return request("GET", `/admin/briefs/${id}`);
+}
+
+export function adminPatchBrief(id: string, patch: BriefContentPatch): Promise<BriefDetail> {
+  return request("PATCH", `/admin/briefs/${id}`, patch);
+}
+
+export function adminApproveBrief(id: string): Promise<{ message: string; brief: BriefDetail }> {
+  return request("POST", `/admin/briefs/${id}/approve`);
+}
+
+export function getPublicBrief(id: string): Promise<PublicBrief> {
+  return request("GET", `/brief/${id}`);
 }

--- a/ui/src/services/api.ts
+++ b/ui/src/services/api.ts
@@ -514,3 +514,19 @@ export function adminApproveBrief(id: string): Promise<{ message: string; brief:
 export function getPublicBrief(id: string): Promise<PublicBrief> {
   return request("GET", `/brief/${id}`);
 }
+
+// --- Admin: hub settings ---
+
+export interface AdminSettings {
+  brief_recipient_emails: string[];
+}
+
+export function adminGetSettings(): Promise<AdminSettings> {
+  return request("GET", "/admin/settings");
+}
+
+export function adminPatchSettings(
+  patch: Partial<AdminSettings>,
+): Promise<AdminSettings> {
+  return request("PATCH", "/admin/settings", patch);
+}


### PR DESCRIPTION
## Summary

Full-stack Slice 3 of the Floyd MVP. When a vote closes, the hub auto-generates a Civic Brief. An admin reviews and approves it via `/admin/briefs`. Approval delivers the brief to the Board of Supervisors via email, publishes it to the public feed, and finalizes the underlying vote. All events spec-compliant per Civic Event Spec v0.1 and Civic Process Spec v0.1.

## What's in this PR

**Backend — new `civic.brief` module** (`civic-hub/src/modules/civic.brief/`)
- Portable plugin — hubs opt in by registering `civic.brief`, opt out by not registering. Self-contained (models, lifecycle, events, service, email, index).
- State: `publication_status` (pending → approved → published) layered on top of the process-level lifecycle states.
- Service exposes `createBriefState`, `editBrief`, and `approveBrief` (the full orchestration).

**Backend — vote lifecycle changes**
- `closeVote` now emits both `civic.process.ended` and `civic.process.aggregation_completed` on close (spec Phase 4).
- `process.finalize` HTTP action removed from the vote adapter. `finalizeVote` stays as a library-only function that the brief approval flow imports directly. This closes the gap where any caller could publish a vote result without brief approval.
- `process.close` in the vote adapter spawns a brief (when `civic.brief` is registered) via the factory, emits the brief's `aggregation_completed`, and links the vote back via `follow_up_process_ids` (Civic Process Spec §11.3).

**Backend — central `action_url` fix**
- New `CIVIC_UI_BASE_URL` env var (falls back to `BASE_URL`) supplies the UI origin for `action_url` construction.
- `eventEmitter` accepts an optional `action_url_path` so briefs can emit events pointing at `/brief/:id`.
- Resolves Slice 1's "action_url points to API origin, not UI origin" follow-up. Forward-compat for federation.

**Backend — routes + orchestration**
- `GET /admin/briefs`, `GET /admin/briefs/:id`, `PATCH /admin/briefs/:id`, `POST /admin/briefs/:id/approve` — all under `requireAdmin`.
- `GET /brief/:id` — public, returns `published` briefs only; pending/approved 404.
- Approval sequence: mark approved → email → record recipients → `outcome_recorded` → mark published → brief `result_published` → finalize linked vote → vote `result_published`. Halts on email failure.
- Public `GET /process` list filters out briefs whose `publication_status !== "published"` so pending brief metadata doesn't leak.
- `services/mailer.ts` — nodemailer with console-log fallback when SMTP env vars are unset (keeps local dev runnable).

**Frontend**
- `/admin/briefs` — list + inline review, with status filters. Admin edits `comments` and `admin_notes`, saves drafts, approves with confirmation.
- `/brief/:id` — clean public brief page with positions rendered as CSS bars.
- `/votes` — now split into **Active / Proposed / Completed**. Each completed vote card shows "View Civic Brief →" when the brief is published, or a "Civic Brief pending review" chip otherwise.
- Feed — `civic.process.result_published` branches by process type: votes render "Vote results published: …", briefs render "Civic Brief delivered: …". Brief events link to `/brief/:id` via the central action_url fix.
- Shared `AdminTabs` component so Proposals and Briefs are one click apart.

## Decisions captured in HANDOFF.md

- Brief content uses a single `comments: string[]` field instead of `concerns` + `suggestions` (user preference mid-slice). Slice 3.5 pre-aggregates `civic.input` bodies into this field; today it's empty until admin types.
- `process.finalize` removed from HTTP entirely (option A); brief module imports `finalizeVote` as a library function. Cleanest gating.
- Shared `/admin` layout with tabs; sub-routes kept for shareable URLs.
- Completed Votes section on `/votes` handles the brief-status transitional state (pending chip / published link).
- Central `action_url` fix applied to all events, not just briefs.

## New environment variables

All documented in `civic-hub/.env.example`:
- `CIVIC_UI_BASE_URL` — optional; defaults to `BASE_URL`.
- `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`, `SMTP_FROM` — all five or nothing; unset = console-log fallback.
- `BOARD_RECIPIENT_EMAIL` — required for approval; unset = 503.

## Test plan

- [ ] `npm run build` passes on both backend (`civic-hub/`) and frontend (`civic-hub/ui/`) — done pre-push; no TS errors.
- [ ] `/votes` shows three sections. Completed section renders "pending" chip if no brief exists yet, "View Civic Brief →" link if published.
- [ ] `/admin/briefs` renders list with status filter tabs. Review view allows editing + approving.
- [ ] On approval, email fires (console-log if SMTP unset), feed gets a "Civic Brief delivered" post, brief appears at `/brief/:id`, linked vote transitions to `finalized`.
- [ ] `GET /brief/:id` returns 404 for pending/approved briefs; 200 for published.
- [ ] Admin routes return 401/403 when unauth'd; 200 when email is in `CIVIC_ADMIN_EMAILS`.
- [ ] A hub with `civic.brief` unregistered boots cleanly; vote close just proceeds without spawning a brief.

## Out of scope (future slices)

- Slice 3.5: populate `BriefContent.comments` from `civic.input` at generation time.
- Carry the process title in `civic.process.result_published` event data on vote events (briefs already do).
- Theme consolidation (Slice 1 follow-up, tracked in IDEAS.md).
- Multi-admin roles / fine-grained permissions.
- AI moderation, PDF export, richer public brief visuals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)