### PR TITLE
Slice 3.5 — community comments via civic.input

### DIFF
--- a/IDEAS.md
+++ b/IDEAS.md
@@ -74,12 +74,6 @@ code. Ideas for process plugins worth exploring:
 - Theme consolidation — migrate legacy `--text-color` / `--primary-color`
   vars in `ui/src/index.css` to the semantic tokens in
   `ui/src/styles/theme.css`.
-- Slice 3.5: populate `BriefContent.comments` from the `civic.input`
-  stream at brief generation time. Today the array is empty until admin
-  manually enters entries during review. The generator in
-  `civic-hub/src/modules/civic.brief/service.ts` (`generateBriefContent`)
-  should accept the list of community-input bodies and seed
-  `content.comments` with sanitized entries so the admin review starts warm.
 
 ## Governance / Community
 
@@ -103,3 +97,4 @@ When an idea here becomes a GitHub issue, move the entry down here with a
 link. Keeps a paper trail of what was fuzzy thinking that turned real.
 
 - Separate Supabase projects for preview and production → [#2](https://github.com/creatinglake/civic-hub/issues/2)
+- Pre-populate BriefContent.comments from civic.input at generation → shipped in Slice 3.5 (2026-04-22).

--- a/IDEAS.md
+++ b/IDEAS.md
@@ -65,6 +65,15 @@ code. Ideas for process plugins worth exploring:
 - Server-side pagination on `GET /events` once the event store outgrows
   client-side slicing.
 - Event archival / compaction strategy for long-lived hubs.
+- **Scheduled vote closure.** Today `voting_closes_at` is only checked when
+  someone tries to vote after the deadline (fails with "expired") — nothing
+  actually triggers the `process.close` transition, so expired votes sit in
+  `active` state indefinitely with no brief spawned. Right long-term fix is
+  a scheduled task (cron / Vercel cron / Supabase Edge function) that runs
+  nightly, finds `civic.vote` processes past `voting_closes_at`, and closes
+  them via the normal flow (which spawns the brief). For the pilot, an
+  admin "Close voting" emergency button is a workaround — but the clock-
+  driven path is what residents expect.
 
 ## Backend / Spec alignment
 

--- a/scripts/testBriefFlow.ts
+++ b/scripts/testBriefFlow.ts
@@ -153,6 +153,40 @@ async function run(): Promise<void> {
   );
   assert(v1.status === 200, "Vote submitted", v1);
 
+  // 5b. Submit a community comment via civic.input (Slice 3.5)
+  step("5b. Submit community comment");
+  const testComment =
+    "Crosswalk would help families walking from the school. Keep the signal timing short so traffic doesn't back up.";
+  const input = await request<{ id: string; body: string }>(
+    "POST",
+    `/process/${voteId}/input`,
+    { body: testComment },
+    admin.token,
+  );
+  assert(input.status === 201, "Comment submitted (201)", input);
+  assert(input.data.body === testComment, "Stored body matches input");
+
+  // 5c. Verify civic.process.comment_added event fired
+  step("5c. Verify comment_added event");
+  const earlyEvs = await request<{ events: Array<{ event_type: string; process_id: string; data: unknown }> }>(
+    "GET",
+    `/events?process_id=${voteId}`,
+  );
+  const commentEvents = earlyEvs.data.events.filter(
+    (e) => e.event_type === "civic.process.comment_added",
+  );
+  assert(
+    commentEvents.length === 1,
+    "Exactly one civic.process.comment_added event fired",
+    earlyEvs.data.events.map((e) => e.event_type),
+  );
+  const commentData = (commentEvents[0].data as { comment?: { id: string; body_preview: string } })?.comment;
+  assert(commentData?.id === input.data.id, "Event data.comment.id matches input id");
+  assert(
+    typeof commentData?.body_preview === "string" && commentData.body_preview.length <= 200,
+    "Event data.comment.body_preview is trimmed to <=200 chars",
+  );
+
   // 6. Close — should auto-spawn a brief
   step("6. Close vote (spawns brief)");
   const close = await request<{ result: { tally: Record<string, number>; total_votes: number; brief_process_id?: string } }>(
@@ -184,6 +218,21 @@ async function run(): Promise<void> {
   assert(briefTypes.includes("civic.process.created"), "Brief emitted .created");
   assert(briefTypes.includes("civic.process.aggregation_completed"), "Brief emitted .aggregation_completed");
   assert(!voteTypes.includes("civic.process.result_published"), "Vote has NOT published yet (brief-gated)");
+
+  // 7b. Brief was seeded with the community comment from Slice 3.5
+  step("7b. Brief content.comments seeded from civic.input");
+  const briefDetail = await request<{ content: { comments: string[] } }>(
+    "GET",
+    `/admin/briefs/${briefId}`,
+    undefined,
+    admin.token,
+  );
+  assert(briefDetail.status === 200, "Admin GET brief succeeds");
+  assert(
+    briefDetail.data.content.comments.includes(testComment),
+    "Brief content.comments includes the submitted comment",
+    briefDetail.data.content.comments,
+  );
 
   // 8. Vote should link to brief via follow_up_process_ids
   step("8. Vote's follow_up_process_ids points at brief");

--- a/src/controllers/debugController.ts
+++ b/src/controllers/debugController.ts
@@ -10,6 +10,7 @@ import {
   clearProcesses,
 } from "../services/processService.js";
 import { clearEvents, getEventCount } from "../events/eventStore.js";
+import { emitEvent } from "../events/eventEmitter.js";
 import { clearInputs, submitInput } from "../modules/civic.input/index.js";
 import { clearProposals } from "../modules/civic.proposals/index.js";
 import { clearAuth } from "../modules/civic.auth/index.js";
@@ -31,7 +32,11 @@ async function runScenario(
 
   if (scenario.inputs) {
     for (const input of scenario.inputs) {
-      await submitInput(process.id, input.author_id, input.body);
+      await submitInput(process.id, input.author_id, input.body, {
+        hub_id: process.hubId,
+        jurisdiction: process.jurisdiction,
+        emit: emitEvent,
+      });
     }
   }
 

--- a/src/controllers/inputController.ts
+++ b/src/controllers/inputController.ts
@@ -4,6 +4,7 @@ import { Request, Response } from "express";
 import { submitInput, getInputsByProcess } from "../modules/civic.input/index.js";
 import { getProcess } from "../services/processService.js";
 import { getAuthUser } from "../middleware/auth.js";
+import { emitEvent } from "../events/eventEmitter.js";
 
 export async function handleSubmitInput(
   req: Request,
@@ -25,7 +26,11 @@ export async function handleSubmitInput(
     }
 
     const user = getAuthUser(res);
-    const input = await submitInput(processId, user.id, body);
+    const input = await submitInput(processId, user.id, body, {
+      hub_id: process.hubId,
+      jurisdiction: process.jurisdiction,
+      emit: emitEvent,
+    });
     res.status(201).json(input);
   } catch (err) {
     const message = err instanceof Error ? err.message : "Unknown error";

--- a/src/debug/autoSeed.ts
+++ b/src/debug/autoSeed.ts
@@ -13,6 +13,7 @@ import {
   executeAction,
 } from "../services/processService.js";
 import { submitInput } from "../modules/civic.input/index.js";
+import { emitEvent } from "../events/eventEmitter.js";
 import { getEventCount } from "../events/eventStore.js";
 import { getDb } from "../db/client.js";
 import {
@@ -34,7 +35,11 @@ async function runScenario(scenario: SeedScenario): Promise<void> {
 
   if (scenario.inputs) {
     for (const input of scenario.inputs) {
-      await submitInput(proc.id, input.author_id, input.body);
+      await submitInput(proc.id, input.author_id, input.body, {
+        hub_id: proc.hubId,
+        jurisdiction: proc.jurisdiction,
+        emit: emitEvent,
+      });
     }
   }
 

--- a/src/modules/civic.brief/models.ts
+++ b/src/modules/civic.brief/models.ts
@@ -116,6 +116,14 @@ export interface CreateBriefFromVoteInput {
   vote_title: string;
   tally: Record<string, number>; // option → count
   total_votes: number;
+  /**
+   * Community-submitted comment bodies collected via civic.input while the
+   * vote was active. Seeded into the brief's content.comments so admin
+   * review starts with the actual resident voices, not an empty textarea.
+   * Caller is responsible for reading these from civic.input (the brief
+   * module never imports civic.input directly).
+   */
+  comments?: string[];
 }
 
 /** Partial content update used by PATCH /admin/briefs/:id. */

--- a/src/modules/civic.brief/service.ts
+++ b/src/modules/civic.brief/service.ts
@@ -57,8 +57,8 @@ function generateBriefContent(input: CreateBriefFromVoteInput): BriefContent {
     title: input.vote_title,
     participation_count: total,
     position_breakdown,
-    // Empty at generation; Slice 3.5 will populate from civic.input.
-    comments: [],
+    // Seeded from civic.input. Admin can edit these in the review UI.
+    comments: sanitizeList(input.comments ?? []),
     admin_notes: "",
   };
 }

--- a/src/modules/civic.input/index.ts
+++ b/src/modules/civic.input/index.ts
@@ -11,9 +11,10 @@
 
 import { getDb } from "../../db/client.js";
 import { generateId } from "../../utils/id.js";
-import type { CommunityInput } from "./models.js";
+import type { CommunityInput, InputContext } from "./models.js";
+import { BODY_PREVIEW_LEN } from "./models.js";
 
-export type { CommunityInput } from "./models.js";
+export type { CommunityInput, EmitEventFn, InputContext } from "./models.js";
 
 interface InputRow {
   id: string;
@@ -35,17 +36,27 @@ function rowToInput(row: InputRow): CommunityInput {
 
 /**
  * Submit community input for a process.
+ *
+ * Emits `civic.process.comment_added` on success, per Civic Event Spec §4.2
+ * and Civic Process Spec §7.5 (participation actions MUST emit events).
+ * The full body stays in the community_inputs table; the event only carries
+ * an ID reference and a short body preview to keep event payloads small.
+ *
+ * The host hub injects its `emit` function through `ctx` so the module
+ * stays portable — it never imports the hub's event system directly.
  */
 export async function submitInput(
   process_id: string,
   author_id: string,
   body: string,
+  ctx: InputContext,
 ): Promise<CommunityInput> {
   if (!body || body.trim().length === 0) {
     throw new Error("Input body cannot be empty");
   }
 
   const id = generateId("input");
+  const trimmed = body.trim();
 
   const { data, error } = await getDb()
     .from("community_inputs")
@@ -53,13 +64,33 @@ export async function submitInput(
       id,
       process_id,
       author_id,
-      body: body.trim(),
+      body: trimmed,
     })
     .select()
     .single();
 
   if (error) throw new Error(`Input: ${error.message}`);
-  return rowToInput(data as InputRow);
+
+  const input = rowToInput(data as InputRow);
+
+  // Emit the participation event. The preview is truncated so events stay
+  // cheap to index and distribute; consumers that want the full body read
+  // /process/:id/input.
+  await ctx.emit({
+    event_type: "civic.process.comment_added",
+    actor: author_id,
+    process_id,
+    hub_id: ctx.hub_id,
+    jurisdiction: ctx.jurisdiction,
+    data: {
+      comment: {
+        id: input.id,
+        body_preview: trimmed.slice(0, BODY_PREVIEW_LEN),
+      },
+    },
+  });
+
+  return input;
 }
 
 /**

--- a/src/modules/civic.input/models.ts
+++ b/src/modules/civic.input/models.ts
@@ -10,3 +10,35 @@ export interface CommunityInput {
   body: string;
   submitted_at: string; // ISO 8601
 }
+
+/**
+ * Event emission callback — injected by the host hub. Mirrors the pattern
+ * used by civic.vote: the module never imports the hub's event system
+ * directly, keeping it portable across hubs.
+ *
+ * Returns a Promise so the host hub can durably store the event before
+ * the caller proceeds. Callers should always `await` emissions.
+ */
+export interface EmitEventFn {
+  (input: {
+    event_type: string;
+    actor: string;
+    process_id: string;
+    hub_id: string;
+    jurisdiction: string;
+    data: Record<string, unknown>;
+  }): Promise<unknown>;
+}
+
+/**
+ * Context provided by the hub when submitting input, so the module can
+ * emit a spec-compliant event without knowing the hub's identity.
+ */
+export interface InputContext {
+  hub_id: string;
+  jurisdiction: string;
+  emit: EmitEventFn;
+}
+
+/** Max length of `body_preview` carried in comment_added event data. */
+export const BODY_PREVIEW_LEN = 200;

--- a/src/processes/briefProcess.ts
+++ b/src/processes/briefProcess.ts
@@ -43,6 +43,9 @@ const briefProcess: ProcessHandler = {
       vote_title: input.vote_title as string,
       tally: input.tally as Record<string, number>,
       total_votes: input.total_votes as number,
+      comments: Array.isArray(input.comments)
+        ? (input.comments as string[])
+        : undefined,
     };
     return createBriefState(briefInput) as unknown as Record<string, unknown>;
   },

--- a/src/processes/voteProcess.ts
+++ b/src/processes/voteProcess.ts
@@ -22,6 +22,7 @@ import {
 import { recordVote } from "../modules/civic.receipts/index.js";
 import type { BriefProcessState } from "../modules/civic.brief/index.js";
 import { emitBriefAggregationCompleted } from "../modules/civic.brief/events.js";
+import { getInputsByProcess } from "../modules/civic.input/index.js";
 import { getProcessFactory, getProcessHandler } from "./registry.js";
 
 // --- Helpers ---
@@ -55,6 +56,22 @@ async function spawnBriefFromClosedVote(
   voteProcess: Process,
   closeResult: Record<string, unknown>,
 ): Promise<Process> {
+  // Seed the brief with community comments collected during the vote. Best-
+  // effort: if the read fails we proceed with an empty list rather than
+  // block the vote-close flow — admin can still add comments manually.
+  let comments: string[] = [];
+  try {
+    const inputs = await getInputsByProcess(voteProcess.id);
+    comments = inputs
+      .map((i) => i.body.trim())
+      .filter((body) => body.length > 0);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    console.warn(
+      `[voteProcess] Could not read civic.input for brief seeding on ${voteProcess.id}: ${message}`,
+    );
+  }
+
   const factory = getProcessFactory();
   const brief = await factory({
     definition: { type: "civic.brief", version: "0.1" },
@@ -72,6 +89,7 @@ async function spawnBriefFromClosedVote(
       vote_title: voteProcess.title,
       tally: closeResult.tally,
       total_votes: closeResult.total_votes,
+      comments,
     },
   });
 

--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -257,6 +257,61 @@
   font-size: 0.9rem;
 }
 
+.vote-comment-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  margin: 0 0 var(--space-md);
+}
+
+.vote-comment-label {
+  font-family: var(--font-body);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.vote-comment-optional {
+  font-weight: 400;
+  color: var(--color-text-subtle);
+  margin-left: var(--space-xs);
+}
+
+.vote-comment-textarea {
+  width: 100%;
+  padding: var(--space-sm);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-body);
+  font-size: var(--font-size-base);
+  line-height: var(--line-height-base);
+  color: var(--color-text);
+  background: var(--color-surface);
+  resize: vertical;
+}
+
+.vote-comment-textarea:focus {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
+  border-color: var(--color-primary);
+}
+
+.vote-comment-counter {
+  align-self: flex-end;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-subtle);
+}
+
+.vote-comment-warning {
+  margin: var(--space-sm) 0 0;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  background: var(--color-surface-muted);
+  padding: var(--space-sm) var(--space-md);
+  border-radius: var(--radius-sm);
+  border-left: 3px solid var(--color-brand);
+}
+
 /* --- Tally --- */
 
 .tally-row {

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -47,6 +47,7 @@ function AppContent() {
           <Route path="/votes/:id/log" element={<VoteLog />} />
           <Route path="/admin/proposals" element={<AdminProposals />} />
           <Route path="/admin/briefs" element={<AdminBriefs />} />
+          <Route path="/admin/briefs/:id" element={<AdminBriefs />} />
           <Route path="/brief/:id" element={<Brief />} />
           <Route path="/about" element={<About />} />
         </Routes>

--- a/ui/src/components/CommunityInputPanel.tsx
+++ b/ui/src/components/CommunityInputPanel.tsx
@@ -1,15 +1,16 @@
-// CommunityInputPanel — renders community input submission and display.
+// CommunityInputPanel — renders the community comments collected via
+// civic.input for a process.
 //
-// Community input is stored separately from votes and does NOT affect
-// vote tallying or lifecycle transitions. This is an explicit design guardrail.
+// Read-only as of Slice 3.5. Comment submission now happens inside the vote
+// flow in VotePanel so comments are always tied to the act of voting.
+// This panel just displays what residents have already said.
 
-import { useState, useEffect, useCallback } from "react";
+import { useCallback, useEffect, useState } from "react";
 import type { CommunityInput, CommunityInputConfig } from "../services/api";
-import { getInputs, submitInput } from "../services/api";
+import { getInputs } from "../services/api";
 
 interface Props {
   processId: string;
-  actor: string;
   config?: CommunityInputConfig;
 }
 
@@ -24,12 +25,8 @@ function formatRelativeTime(iso: string): string {
   return `${days}d ago`;
 }
 
-export default function CommunityInputPanel({ processId, actor, config }: Props) {
+export default function CommunityInputPanel({ processId, config }: Props) {
   const [inputs, setInputs] = useState<CommunityInput[]>([]);
-  const [body, setBody] = useState("");
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [submitted, setSubmitted] = useState(false);
 
   const fetchInputs = useCallback(() => {
     getInputs(processId)
@@ -41,69 +38,26 @@ export default function CommunityInputPanel({ processId, actor, config }: Props)
     fetchInputs();
   }, [fetchInputs]);
 
-  async function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    if (!body.trim()) return;
+  if (inputs.length === 0) return null;
 
-    setLoading(true);
-    setError(null);
-    try {
-      await submitInput(processId, actor, body.trim());
-      setBody("");
-      setSubmitted(true);
-      fetchInputs();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to submit");
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  const prompt = config?.prompt ?? "Share your perspective on this issue";
-  const label = config?.label ?? "Optional: Your input does not affect vote results";
+  const label = config?.label ?? "Shared alongside residents' votes. Does not affect vote results.";
 
   return (
     <div className="community-input-panel">
-      <h3>Community input</h3>
+      <h3>Community comments</h3>
       <p className="input-label">{label}</p>
 
-      {/* Submission form */}
-      <form className="input-form" onSubmit={handleSubmit}>
-        <textarea
-          className="input-textarea"
-          value={body}
-          onChange={(e) => setBody(e.target.value)}
-          placeholder={prompt}
-          rows={3}
-          disabled={loading}
-        />
-        <div className="input-form-actions">
-          <button
-            type="submit"
-            className="input-submit-button"
-            disabled={loading || !body.trim()}
-          >
-            {loading ? "Submitting..." : "Submit"}
-          </button>
-          {submitted && <span className="input-confirmation">Thank you for sharing your perspective</span>}
-          {error && <span className="error">{error}</span>}
-        </div>
-      </form>
-
-      {/* Existing inputs */}
-      {inputs.length > 0 && (
-        <div className="input-list">
-          <p className="input-count">{inputs.length} response{inputs.length !== 1 ? "s" : ""}</p>
-          {inputs.map((input) => (
-            <div key={input.id} className="input-item">
-              <p className="input-body">{input.body}</p>
-              <span className="input-meta">
-                {input.author_id} &middot; {formatRelativeTime(input.submitted_at)}
-              </span>
-            </div>
-          ))}
-        </div>
-      )}
+      <div className="input-list">
+        <p className="input-count">{inputs.length} comment{inputs.length !== 1 ? "s" : ""}</p>
+        {inputs.map((input) => (
+          <div key={input.id} className="input-item">
+            <p className="input-body">{input.body}</p>
+            <span className="input-meta">
+              {input.author_id} &middot; {formatRelativeTime(input.submitted_at)}
+            </span>
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/ui/src/components/VotePanel.tsx
+++ b/ui/src/components/VotePanel.tsx
@@ -1,9 +1,11 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
 import type { VoteState } from "../services/api";
-import { submitVote, supportVote, unsupportVote } from "../services/api";
+import { submitVote, supportVote, unsupportVote, submitInput } from "../services/api";
 import { useRequireAuth } from "../hooks/useRequireAuth";
 import AuthModal from "./AuthModal";
+
+const COMMENT_MAX = 500;
 
 interface Props {
   process: VoteState;
@@ -16,6 +18,9 @@ export default function VotePanel({ process, actor, onVoted }: Props) {
   const [error, setError] = useState<string | null>(null);
   const [justVoted, setJustVoted] = useState<string | null>(null);
   const [receiptId, setReceiptId] = useState<string | null>(null);
+  const [comment, setComment] = useState("");
+  const [commentSubmitted, setCommentSubmitted] = useState(false);
+  const [commentWarning, setCommentWarning] = useState<string | null>(null);
   const { requireAuth, showAuthModal, closeAuthModal, handleAuthComplete } = useRequireAuth();
 
   const isActive = process.status === "active";
@@ -27,11 +32,30 @@ export default function VotePanel({ process, actor, onVoted }: Props) {
   async function doVote(option: string) {
     setLoading(true);
     setError(null);
+    setCommentWarning(null);
     try {
       const result = await submitVote(process.id, actor, option);
       const receipt = (result.result as Record<string, unknown>)?.receipt_id as string | undefined;
       setJustVoted(option);
       if (receipt) setReceiptId(receipt);
+
+      // If the resident also typed a comment, submit it after the vote
+      // succeeds. Parallel data stream via civic.input — a comment failure
+      // does NOT roll back the vote; we surface a non-fatal warning instead.
+      const trimmed = comment.trim();
+      if (trimmed.length > 0) {
+        try {
+          await submitInput(process.id, actor, trimmed);
+          setCommentSubmitted(true);
+          setComment("");
+        } catch (commentErr) {
+          const msg = commentErr instanceof Error ? commentErr.message : "Failed to submit comment";
+          setCommentWarning(
+            `Your vote was recorded, but the comment couldn't be saved: ${msg}`,
+          );
+        }
+      }
+
       onVoted();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Vote failed");
@@ -142,6 +166,28 @@ export default function VotePanel({ process, actor, onVoted }: Props) {
         <div className="vote-options">
           <h4>Cast your vote</h4>
           <p className="vote-privacy-notice">Votes are private. Only total results are shown.</p>
+
+          {!justVoted && (
+            <div className="vote-comment-field">
+              <label className="vote-comment-label" htmlFor="vote-comment">
+                Your comment <span className="vote-comment-optional">(optional)</span>
+              </label>
+              <textarea
+                id="vote-comment"
+                className="vote-comment-textarea"
+                value={comment}
+                onChange={(e) => setComment(e.target.value.slice(0, COMMENT_MAX))}
+                placeholder="Share concerns, suggestions, context, or any thoughts worth passing on to the Board. Submitted when you cast your vote."
+                rows={3}
+                maxLength={COMMENT_MAX}
+                disabled={loading}
+              />
+              <span className="vote-comment-counter">
+                {comment.length} / {COMMENT_MAX}
+              </span>
+            </div>
+          )}
+
           <div className="vote-buttons">
             {process.options.map((option) => (
               <button
@@ -154,6 +200,14 @@ export default function VotePanel({ process, actor, onVoted }: Props) {
               </button>
             ))}
           </div>
+          {justVoted && commentSubmitted && (
+            <p className="vote-confirmation">
+              Your vote and comment have been submitted.
+            </p>
+          )}
+          {commentWarning && (
+            <p className="vote-comment-warning">{commentWarning}</p>
+          )}
           {justVoted && (
             <div className="vote-receipt">
               <p className="vote-receipt-title">Your vote has been recorded</p>

--- a/ui/src/pages/AdminBriefs.tsx
+++ b/ui/src/pages/AdminBriefs.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
 import {
   adminListBriefs,
   adminGetBrief,
@@ -13,8 +14,6 @@ import {
 import AdminTabs from "../components/AdminTabs";
 import "./AdminBriefs.css";
 
-type View = "list" | "review";
-
 const STATUS_FILTERS: Array<{ id: "all" | BriefPublicationStatus; label: string }> = [
   { id: "all", label: "All" },
   { id: "pending", label: "Pending" },
@@ -23,7 +22,10 @@ const STATUS_FILTERS: Array<{ id: "all" | BriefPublicationStatus; label: string 
 ];
 
 export default function AdminBriefs() {
-  const [view, setView] = useState<View>("list");
+  const navigate = useNavigate();
+  const { id: routeBriefId } = useParams<{ id?: string }>();
+  const view: "list" | "review" = routeBriefId ? "review" : "list";
+
   const [briefs, setBriefs] = useState<BriefSummary[]>([]);
   const [selected, setSelected] = useState<BriefDetail | null>(null);
   const [statusFilter, setStatusFilter] = useState<"all" | BriefPublicationStatus>("all");
@@ -100,25 +102,35 @@ export default function AdminBriefs() {
   function openReview(id: string) {
     setError(null);
     setActionMessage(null);
-    adminGetBrief(id)
+    navigate(`/admin/briefs/${id}`);
+  }
+
+  function backToList() {
+    setConfirmingApprove(false);
+    setActionMessage(null);
+    setError(null);
+    navigate("/admin/briefs");
+  }
+
+  // Load the selected brief whenever the URL id changes. When we navigate
+  // back to /admin/briefs (no id), clear the selection so stale state
+  // doesn't flash on next entry.
+  useEffect(() => {
+    if (!routeBriefId) {
+      setSelected(null);
+      return;
+    }
+    setError(null);
+    setActionMessage(null);
+    adminGetBrief(routeBriefId)
       .then((brief) => {
         setSelected(brief);
         setCommentsText(brief.content.comments.join("\n"));
         setAdminNotes(brief.content.admin_notes);
-        setView("review");
         setConfirmingApprove(false);
       })
-      .catch((err) => setError(err.message));
-  }
-
-  function backToList() {
-    setSelected(null);
-    setView("list");
-    setConfirmingApprove(false);
-    setActionMessage(null);
-    setError(null);
-    loadList();
-  }
+      .catch((err: Error) => setError(err.message));
+  }, [routeBriefId]);
 
   async function saveDraft() {
     if (!selected) return;

--- a/ui/src/pages/Process.tsx
+++ b/ui/src/pages/Process.tsx
@@ -148,12 +148,13 @@ export default function Process() {
         <IssueContent content={voteState.content} />
       )}
 
-      {/* Community input (only for processes that enable it) */}
-      {isVote && id && voteState?.content?.community_input && (
+      {/* Community comments — show for any vote with collected inputs.
+          Submission now happens inline with voting via VotePanel's comment
+          textarea; this panel is read-only display of past comments. */}
+      {isVote && id && (
         <CommunityInputPanel
           processId={id}
-          actor={currentActor}
-          config={voteState.content.community_input}
+          config={voteState?.content?.community_input}
         />
       )}
     </div>


### PR DESCRIPTION
Closes the Civic Event Spec §4.2 / Process Spec §7.5 gap: civic.input.submitInput now emits civic.process.comment_added. Vote flow wires an optional comment textarea that submits via civic.input after a successful vote. civic.brief's generator seeds content.comments from civic.input at spawn time. CommunityInputPanel goes read-only. All 22 assertions in testBriefFlow.ts pass end-to-end. See HANDOFF.md for details.