### PR TITLE
Slice 4 — Board announcements (civic.announcement)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,7 +39,16 @@ CIVIC_ALLOWED_ORIGINS=
 # Comma-separated list of admin emails. Admin routes (/admin/*) require the
 # authenticated user's email to appear in this list (case-insensitive).
 # If unset, all admin routes return 503 (safe-by-default — no silent admins).
+# Admins can do everything Board members can (see CIVIC_BOARD_EMAILS) plus
+# proposal review, brief review/approval, and delivery settings.
 CIVIC_ADMIN_EMAILS=
+
+# Comma-separated list of Board member emails. Narrow role: users in this
+# list can post and edit /announcement/* entries but cannot access any
+# /admin/* route. If a user's email is in both CIVIC_ADMIN_EMAILS and
+# CIVIC_BOARD_EMAILS, admin wins (full privileges). Case-insensitive.
+# If unset, nobody has the board role — only admins can post announcements.
+CIVIC_BOARD_EMAILS=
 
 # Node environment. Set to "production" on Vercel Production.
 NODE_ENV=development

--- a/IDEAS.md
+++ b/IDEAS.md
@@ -36,8 +36,8 @@ code. Ideas for process plugins worth exploring:
 
 - `civic.petition` — signature-collection process with a support threshold
   and a public outcome.
-- `civic.announcement` — non-interactive news posts that surface in the feed
-  but don't accept actions.
+- ~~`civic.announcement` — non-interactive news posts that surface in the feed
+  but don't accept actions.~~ Shipped in Slice 4 (2026-04-22).
 - `civic.deliberation` — structured discussion with framing prompts, before a
   vote opens.
 - `civic.budget` — participatory budgeting (allocate a fixed pool across
@@ -88,6 +88,29 @@ code. Ideas for process plugins worth exploring:
 - Politician / official profiles tied to jurisdictions, with verified
   channels for posting responses to community votes.
 - Credential issuance (residency, voter registration) as civic-issued VCs.
+- **User-record roles (replaces env-var email lists).** Today admin and
+  Board roles come from `CIVIC_ADMIN_EMAILS` / `CIVIC_BOARD_EMAILS`
+  env vars. For the pilot that's fine — the lists are tiny. As the hub
+  scales or federates, migrate to a per-user role column in the users
+  table so role assignment is a DB operation (admin-editable UI) and
+  doesn't require a redeploy per change.
+- **Announcement retraction.** Slice 4 supports edits but not deletion
+  or retraction. An announcement that was sent in error may need to be
+  withdrawn transparently (emit `civic.process.retracted`, keep the
+  record visible but marked "retracted", preserve edit history). Spec
+  would need a new canonical event type for this.
+
+## Protocol / Federation (further)
+
+- **Informational `process_kind`.** Spec §5 assumes all processes
+  implement Phases 0–6 with meaningful civic activity in each. Slice 4's
+  `civic.announcement` skips Phases 1–5 because they don't correspond to
+  anything real for an instant-publish informational post. Worth
+  proposing a spec extension that formalizes three process kinds:
+  participation-driven (civic.vote, civic.petition),
+  derivative (civic.brief), and informational (civic.announcement), each
+  with its own phase-compliance rules. Makes conformance checks clearer
+  and helps federated consumers interpret incoming process descriptors.
 
 ## Observability of civic impact
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -15,6 +15,8 @@ import adminRoutes from "./routes/adminRoutes.js";
 import authRoutes from "./routes/authRoutes.js";
 import voteLogRoutes from "./routes/voteLogRoutes.js";
 import briefRoutes from "./routes/briefRoutes.js";
+import announcementRoutes from "./routes/announcementRoutes.js";
+import { handleListAnnouncements } from "./controllers/announcementController.js";
 import { ensureSeeded } from "./debug/autoSeed.js";
 import { pingDb } from "./db/client.js";
 
@@ -81,6 +83,11 @@ app.use("/votes", voteLogRoutes);
 // Civic Briefs — public read of published briefs
 app.use("/brief", briefRoutes);
 
+// Board / Admin announcements — post, edit, read one
+app.use("/announcement", announcementRoutes);
+// Public list — separate path so it doesn't collide with /announcement/:id
+app.get("/announcements", handleListAnnouncements);
+
 // --- Primary public interfaces ---
 // Events are the PRIMARY public interface of the hub.
 // All external systems (feeds, dashboards, federation) should rely on events.
@@ -126,6 +133,10 @@ app.get("/", (_req, res) => {
       "PATCH /admin/briefs/:id": "Edit brief concerns/suggestions/notes (pending only)",
       "POST /admin/briefs/:id/approve": "Approve brief: email + publish",
       "GET /brief/:id": "Public read of a published civic brief",
+      "POST /announcement": "Post a Board announcement (Board or admin)",
+      "PATCH /announcement/:id": "Edit an announcement (author only, or any admin)",
+      "GET /announcement/:id": "Public read of an announcement",
+      "GET /announcements": "List announcements, newest first (optional ?limit=N)",
       "GET /events": "List all events (primary public interface)",
       "GET /events?process_id=X": "Filter events by process",
       "GET /events?type=X": "Filter events by type (e.g., civic.process.vote_submitted)",

--- a/src/controllers/announcementController.ts
+++ b/src/controllers/announcementController.ts
@@ -1,0 +1,230 @@
+// Announcement controller — Board / admin posting and editing, plus the
+// public read surface.
+//
+// POST /announcement            — create (requireBoardOrAdmin)
+// PATCH /announcement/:id       — edit (requireBoardOrAdmin + authorship check inside)
+// GET /announcement/:id         — public read
+// GET /announcements            — public list
+
+import { Request, Response } from "express";
+import {
+  emitPublicationEvents,
+  getPublicReadModel,
+  getPublicSummary,
+  updateAnnouncement,
+  type AnnouncementAuthorRole,
+  type AnnouncementContentPatch,
+  type AnnouncementLink,
+  type AnnouncementProcessState,
+} from "../modules/civic.announcement/index.js";
+import { emitEvent } from "../events/eventEmitter.js";
+import {
+  createProcess,
+  getAllProcesses,
+  getProcess,
+  saveProcessState,
+} from "../services/processService.js";
+import { getAuthUser } from "../middleware/auth.js";
+
+function getState(record: { state: Record<string, unknown> }): AnnouncementProcessState {
+  return record.state as unknown as AnnouncementProcessState;
+}
+
+function ctxFor(record: { id: string; hubId: string; jurisdiction: string }) {
+  return {
+    process_id: record.id,
+    hub_id: record.hubId,
+    jurisdiction: record.jurisdiction,
+    emit: emitEvent,
+  };
+}
+
+/** Read an announcement's links payload from a request body, or return []. */
+function readLinks(body: unknown): AnnouncementLink[] | undefined {
+  const b = body as { links?: unknown } | null | undefined;
+  if (!b || b.links === undefined) return undefined;
+  if (!Array.isArray(b.links)) {
+    throw new Error("links must be an array");
+  }
+  return b.links
+    .filter(
+      (l): l is { label: string; url: string } =>
+        typeof l === "object" &&
+        l !== null &&
+        typeof (l as { label?: unknown }).label === "string" &&
+        typeof (l as { url?: unknown }).url === "string",
+    )
+    .map((l) => ({ label: l.label, url: l.url }));
+}
+
+export async function handleCreateAnnouncement(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  try {
+    const user = getAuthUser(res);
+    const role = res.locals.effectiveRole as AnnouncementAuthorRole;
+    const body = (req.body ?? {}) as { title?: unknown; body?: unknown };
+
+    if (typeof body.title !== "string" || typeof body.body !== "string") {
+      res.status(400).json({ error: "title and body are required (string)." });
+      return;
+    }
+
+    const links = readLinks(req.body);
+
+    // Spawn the process via the generic factory so the created event is
+    // emitted consistently. The announcement module's publication events
+    // fire separately below.
+    const record = await createProcess({
+      definition: { type: "civic.announcement", version: "0.1" },
+      title: body.title,
+      description: body.body, // descriptor shows the body as description for list consumers
+      createdBy: user.id,
+      state: {
+        title: body.title,
+        body: body.body,
+        author_id: user.id,
+        author_role: role,
+        links: links ?? [],
+      },
+    });
+
+    // The generic factory emitted civic.process.created with a minimal
+    // payload. Our module fires BOTH created (with announcement-specific
+    // data) and result_published. To avoid duplicate `created` events,
+    // emit only result_published here. The Feed's event-type filter will
+    // ignore the generic created event from the generic factory for
+    // civic.announcement (see FeedPost.tsx).
+    const state = getState(record);
+    const ctx = ctxFor(record);
+    // The module's emitPublicationEvents fires both created + result_published,
+    // which would duplicate the generic created. We want only the module's
+    // richer `created` plus `result_published`, so we also need the generic
+    // created to be filtered client-side. Simpler: just fire result_published
+    // here. The generic created from processService already carries type +
+    // title, which is enough for consumers that only look at core fields.
+    const events = await import("../modules/civic.announcement/events.js");
+    await events.emitAnnouncementResultPublished(ctx, user.id, state);
+
+    // Auto-finalize the process status — announcements are instant-publish.
+    record.status = "finalized";
+    await saveProcessState(record);
+
+    res.status(201).json(
+      getPublicReadModel(state, { id: record.id, createdAt: record.createdAt }),
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    res.status(400).json({ error: message });
+  }
+}
+
+export async function handleUpdateAnnouncement(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  try {
+    const id = req.params.id as string;
+    const record = await getProcess(id);
+    if (!record || record.definition.type !== "civic.announcement") {
+      res.status(404).json({ error: "Announcement not found" });
+      return;
+    }
+    const user = getAuthUser(res);
+    const role = res.locals.effectiveRole as AnnouncementAuthorRole;
+
+    const body = (req.body ?? {}) as {
+      title?: unknown;
+      body?: unknown;
+      links?: unknown;
+    };
+    const patch: AnnouncementContentPatch = {};
+    if (typeof body.title === "string") patch.title = body.title;
+    if (typeof body.body === "string") patch.body = body.body;
+    if (body.links !== undefined) {
+      const links = readLinks(req.body);
+      if (links !== undefined) patch.links = links;
+    }
+
+    const state = getState(record);
+    try {
+      const outcome = await updateAnnouncement(
+        state,
+        { id: user.id, role },
+        patch,
+        ctxFor(record),
+      );
+      await saveProcessState(record);
+      res.json({
+        ...getPublicReadModel(outcome.state, {
+          id: record.id,
+          createdAt: record.createdAt,
+        }),
+        edited_fields: outcome.result.edited_fields,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Unknown error";
+      if (message.startsWith("Not authorized")) {
+        res.status(403).json({ error: message });
+      } else {
+        res.status(400).json({ error: message });
+      }
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    res.status(500).json({ error: message });
+  }
+}
+
+export async function handleGetAnnouncement(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  try {
+    const id = req.params.id as string;
+    const record = await getProcess(id);
+    if (!record || record.definition.type !== "civic.announcement") {
+      res.status(404).json({ error: "Announcement not found" });
+      return;
+    }
+    res.json(
+      getPublicReadModel(getState(record), {
+        id: record.id,
+        createdAt: record.createdAt,
+      }),
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    res.status(500).json({ error: message });
+  }
+}
+
+export async function handleListAnnouncements(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  try {
+    const limitRaw = req.query.limit as string | undefined;
+    const limit = limitRaw ? Math.max(1, Math.min(200, parseInt(limitRaw, 10))) : undefined;
+
+    const all = await getAllProcesses();
+    const summaries = all
+      .filter((p) => p.definition.type === "civic.announcement")
+      .sort(
+        (a, b) =>
+          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+      )
+      .map((p) =>
+        getPublicSummary(getState(p), {
+          id: p.id,
+          createdAt: p.createdAt,
+        }),
+      );
+
+    res.json(limit ? summaries.slice(0, limit) : summaries);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    res.status(500).json({ error: message });
+  }
+}

--- a/src/controllers/authController.ts
+++ b/src/controllers/authController.ts
@@ -15,6 +15,7 @@ import {
   getUserFromToken,
   logout,
 } from "../modules/civic.auth/index.js";
+import { roleForEmail } from "../middleware/auth.js";
 
 /**
  * POST /auth/request-code
@@ -57,7 +58,9 @@ export async function handleVerify(
 
   try {
     const result = await verifyCode(email, code);
-    res.json(result);
+    // Include role alongside the token + user so the UI gets the admin /
+    // board bit without a follow-up /auth/me roundtrip on login.
+    res.json({ ...result, role: roleForEmail(result.user?.email) });
   } catch (err) {
     const message = err instanceof Error ? err.message : "Unknown error";
     res.status(400).json({ error: message });
@@ -113,7 +116,9 @@ export async function handleGetMe(
     return;
   }
 
-  res.json({ user });
+  // Include the derived role so the UI can gate admin-only / Board-or-admin
+  // controls without hardcoding emails. null for residents.
+  res.json({ user, role: roleForEmail(user.email) });
 }
 
 /**

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -20,14 +20,35 @@ function extractToken(req: Request): string | null {
   return null;
 }
 
-function adminEmails(): Set<string> {
-  const raw = process.env.CIVIC_ADMIN_EMAILS ?? "";
+function parseEmailList(raw: string | undefined): Set<string> {
   return new Set(
-    raw
+    (raw ?? "")
       .split(",")
       .map((e) => e.trim().toLowerCase())
       .filter((e) => e.length > 0),
   );
+}
+
+function adminEmails(): Set<string> {
+  return parseEmailList(process.env.CIVIC_ADMIN_EMAILS);
+}
+
+function boardEmails(): Set<string> {
+  return parseEmailList(process.env.CIVIC_BOARD_EMAILS);
+}
+
+/**
+ * Derive the effective role for a user based on their email. Admins win
+ * if their email is in both lists (so an admin who's also listed as a
+ * Board member gets full admin privileges, not the narrower Board role).
+ * Returns null if the user has no elevated role.
+ */
+export function roleForEmail(email: string | undefined | null): "admin" | "board" | null {
+  if (!email) return null;
+  const lower = email.toLowerCase();
+  if (adminEmails().has(lower)) return "admin";
+  if (boardEmails().has(lower)) return "board";
+  return null;
 }
 
 /**
@@ -108,6 +129,38 @@ export async function requireAdmin(
       res.status(403).json({ error: "Admin access required" });
       return;
     }
+    next();
+  });
+}
+
+/**
+ * Require an authenticated user whose email is in either
+ * CIVIC_BOARD_EMAILS or CIVIC_ADMIN_EMAILS. Used for announcement
+ * operations (post / edit).
+ *
+ * Sets `res.locals.effectiveRole` to `"admin"` or `"board"` so handlers
+ * can stamp the author role on new announcements without recomputing.
+ *
+ * This is intentionally separate from requireAdmin: Board members get
+ * this one capability (announcements) and nothing else. /admin/* routes
+ * keep using requireAdmin (strict) so Board members can't reach them.
+ */
+export async function requireBoardOrAdmin(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  await requireAuth(req, res, async () => {
+    const user = res.locals.authUser as User | undefined;
+    if (!user) return;
+
+    const role = roleForEmail(user.email);
+    if (role === null) {
+      res.status(403).json({ error: "Board or admin access required" });
+      return;
+    }
+
+    res.locals.effectiveRole = role;
     next();
   });
 }

--- a/src/modules/civic.announcement/events.ts
+++ b/src/modules/civic.announcement/events.ts
@@ -1,0 +1,100 @@
+// civic.announcement module — event emission helpers
+//
+// Per Civic Event Spec v0.1 §4-5. action_url_path points events at the
+// public announcement page so feed posts and federated consumers route
+// to the human-facing UI rather than the JSON API.
+
+import type {
+  AnnouncementContentPatch,
+  AnnouncementProcessContext,
+  AnnouncementProcessState,
+} from "./models.js";
+import { BODY_PREVIEW_LEN } from "./models.js";
+
+function announcementPath(process_id: string): string {
+  return `/announcement/${process_id}`;
+}
+
+function bodyPreview(body: string): string {
+  return body.trim().slice(0, BODY_PREVIEW_LEN);
+}
+
+export async function emitAnnouncementCreated(
+  ctx: AnnouncementProcessContext,
+  actor: string,
+  state: AnnouncementProcessState,
+): Promise<void> {
+  await ctx.emit({
+    event_type: "civic.process.created",
+    actor,
+    process_id: ctx.process_id,
+    hub_id: ctx.hub_id,
+    jurisdiction: ctx.jurisdiction,
+    action_url_path: announcementPath(ctx.process_id),
+    data: {
+      announcement: {
+        title: state.content.title,
+        body_preview: bodyPreview(state.content.body),
+        author_role: state.author_role,
+      },
+    },
+  });
+}
+
+/**
+ * Emitted immediately after `created` — announcements skip Phases 1–5
+ * and go directly to publication. See HANDOFF.md for the spec-compliance
+ * note about skipped phases for instant-publish announcements.
+ */
+export async function emitAnnouncementResultPublished(
+  ctx: AnnouncementProcessContext,
+  actor: string,
+  state: AnnouncementProcessState,
+): Promise<void> {
+  await ctx.emit({
+    event_type: "civic.process.result_published",
+    actor,
+    process_id: ctx.process_id,
+    hub_id: ctx.hub_id,
+    jurisdiction: ctx.jurisdiction,
+    action_url_path: announcementPath(ctx.process_id),
+    data: {
+      announcement: {
+        id: ctx.process_id,
+        title: state.content.title,
+        author_role: state.author_role,
+      },
+    },
+  });
+}
+
+export async function emitAnnouncementUpdated(
+  ctx: AnnouncementProcessContext,
+  actor: string,
+  state: AnnouncementProcessState,
+  editedFields: Array<"title" | "body" | "links">,
+): Promise<void> {
+  await ctx.emit({
+    event_type: "civic.process.updated",
+    actor,
+    process_id: ctx.process_id,
+    hub_id: ctx.hub_id,
+    jurisdiction: ctx.jurisdiction,
+    action_url_path: announcementPath(ctx.process_id),
+    data: {
+      announcement: {
+        title: state.content.title,
+        body_preview: bodyPreview(state.content.body),
+        edit_count: state.edit_count,
+        edited_fields: editedFields,
+      },
+    },
+  });
+}
+
+// Re-export for the adapter that needs the raw preview util (keeps the
+// module as the single source of truth for preview length).
+export { bodyPreview };
+
+// Make TS happy if nothing else references the patch type yet; harmless.
+export type { AnnouncementContentPatch };

--- a/src/modules/civic.announcement/index.ts
+++ b/src/modules/civic.announcement/index.ts
@@ -1,0 +1,52 @@
+// civic.announcement module — public surface
+
+export type {
+  AnnouncementActionOutcome,
+  AnnouncementAuthorRole,
+  AnnouncementContent,
+  AnnouncementContentPatch,
+  AnnouncementLink,
+  AnnouncementProcessContext,
+  AnnouncementProcessState,
+  CreateAnnouncementInput,
+  EmitEventFn,
+} from "./models.js";
+
+export {
+  BODY_MAX,
+  BODY_PREVIEW_LEN,
+  LINK_LABEL_MAX,
+  LINK_URL_MAX,
+  LINKS_MAX,
+  TITLE_MAX,
+} from "./models.js";
+
+export { canEdit } from "./lifecycle.js";
+
+export {
+  createAnnouncementState,
+  emitPublicationEvents,
+  getPublicReadModel,
+  getPublicSummary,
+  updateAnnouncement,
+} from "./service.js";
+
+export const PROCESS_DESCRIPTOR = {
+  type: "civic.announcement",
+  version: "0.1",
+  lifecycle: {
+    // Instant-publish: Phase 0 (Initiation) → Phase 6 (Publication) directly.
+    // Spec Phases 1–5 are intentionally skipped for this process kind.
+    // See HANDOFF.md and the process_kind discussion.
+    states: ["finalized"],
+  },
+  actions: [
+    // All transitions happen via the /announcement HTTP surface, not the
+    // generic /process/:id/action dispatcher.
+  ],
+  events: [
+    "civic.process.created",
+    "civic.process.result_published",
+    "civic.process.updated",
+  ],
+} as const;

--- a/src/modules/civic.announcement/lifecycle.ts
+++ b/src/modules/civic.announcement/lifecycle.ts
@@ -1,0 +1,22 @@
+// civic.announcement module — lifecycle helpers
+//
+// Announcements are instant-publish: no draft, scheduled, active, or
+// closed state. The standard process.status is "finalized" from the
+// moment of creation and stays there through edits.
+//
+// Authorization to edit:
+//   - The original author can always edit their own announcement.
+//   - A user with admin role can edit any announcement (e.g. to correct
+//     a factual error or enforce policy).
+//   - A Board member cannot edit another Board member's announcement.
+
+import type { AnnouncementProcessState, AnnouncementAuthorRole } from "./models.js";
+
+export function canEdit(
+  state: AnnouncementProcessState,
+  editorId: string,
+  editorRole: AnnouncementAuthorRole,
+): boolean {
+  if (editorRole === "admin") return true;
+  return state.author_id === editorId;
+}

--- a/src/modules/civic.announcement/models.ts
+++ b/src/modules/civic.announcement/models.ts
@@ -1,0 +1,86 @@
+// civic.announcement module — type definitions
+//
+// Announcements are one-way communications from Board members (or admins)
+// to residents. Instant-publish on create: Phase 0 → Phase 6 directly,
+// with no framing, activation, participation, aggregation, or outcome.
+// Edits are allowed and transparent (edit_count increments, `updated`
+// event emitted).
+//
+// The module is self-contained and portable. The host hub injects the
+// event emit function via AnnouncementProcessContext; the module never
+// imports the hub's event system directly.
+
+export type AnnouncementAuthorRole = "board" | "admin";
+
+export interface AnnouncementLink {
+  label: string;
+  url: string;
+}
+
+export interface AnnouncementContent {
+  title: string;           // required, <= TITLE_MAX
+  body: string;            // required, plain text, <= BODY_MAX
+  links: AnnouncementLink[]; // optional, <= LINKS_MAX
+}
+
+export interface AnnouncementProcessState {
+  type: "civic.announcement";
+  content: AnnouncementContent;
+  author_id: string;
+  author_role: AnnouncementAuthorRole;
+  created_at: string;       // ISO 8601
+  last_edited_at: string | null;
+  edit_count: number;
+}
+
+/** Length caps enforced by the module (also enforced client-side). */
+export const TITLE_MAX = 200;
+export const BODY_MAX = 5000;
+export const LINKS_MAX = 5;
+export const LINK_LABEL_MAX = 100;
+export const LINK_URL_MAX = 500;
+/** First N chars of the body included in event data as a preview. */
+export const BODY_PREVIEW_LEN = 200;
+
+/**
+ * Event emission callback — injected by the host hub.
+ */
+export interface EmitEventFn {
+  (input: {
+    event_type: string;
+    actor: string;
+    process_id: string;
+    hub_id: string;
+    jurisdiction: string;
+    data: Record<string, unknown>;
+    action_url_path?: string;
+  }): Promise<unknown>;
+}
+
+export interface AnnouncementProcessContext {
+  process_id: string;
+  hub_id: string;
+  jurisdiction: string;
+  emit: EmitEventFn;
+}
+
+export interface AnnouncementActionOutcome {
+  state: AnnouncementProcessState;
+  result: Record<string, unknown>;
+}
+
+/** Input when a Board member / admin creates an announcement. */
+export interface CreateAnnouncementInput {
+  title: string;
+  body: string;
+  links?: AnnouncementLink[];
+  author_id: string;
+  author_role: AnnouncementAuthorRole;
+}
+
+/** Partial update used by PATCH /announcement/:id. */
+export interface AnnouncementContentPatch {
+  title?: string;
+  body?: string;
+  links?: AnnouncementLink[];
+}

--- a/src/modules/civic.announcement/service.ts
+++ b/src/modules/civic.announcement/service.ts
@@ -1,0 +1,192 @@
+// civic.announcement module — service functions (pure state transitions)
+//
+// No I/O beyond the injected emit callback. Persistence of state changes
+// is the host hub's responsibility (via processService.saveProcessState).
+
+import type {
+  AnnouncementActionOutcome,
+  AnnouncementContent,
+  AnnouncementContentPatch,
+  AnnouncementLink,
+  AnnouncementProcessContext,
+  AnnouncementProcessState,
+  CreateAnnouncementInput,
+} from "./models.js";
+import {
+  BODY_MAX,
+  LINK_LABEL_MAX,
+  LINK_URL_MAX,
+  LINKS_MAX,
+  TITLE_MAX,
+} from "./models.js";
+import { canEdit } from "./lifecycle.js";
+import {
+  emitAnnouncementCreated,
+  emitAnnouncementResultPublished,
+  emitAnnouncementUpdated,
+} from "./events.js";
+
+export function createAnnouncementState(
+  input: CreateAnnouncementInput,
+): AnnouncementProcessState {
+  const content = sanitizeContent({
+    title: input.title,
+    body: input.body,
+    links: input.links ?? [],
+  });
+  return {
+    type: "civic.announcement",
+    content,
+    author_id: input.author_id,
+    author_role: input.author_role,
+    created_at: new Date().toISOString(),
+    last_edited_at: null,
+    edit_count: 0,
+  };
+}
+
+/**
+ * Emit the two instant-publish events: created, then result_published.
+ * Called by the host hub once the row is persisted.
+ */
+export async function emitPublicationEvents(
+  ctx: AnnouncementProcessContext,
+  actor: string,
+  state: AnnouncementProcessState,
+): Promise<void> {
+  await emitAnnouncementCreated(ctx, actor, state);
+  await emitAnnouncementResultPublished(ctx, actor, state);
+}
+
+/**
+ * Apply an edit. Authorization check lives here so it's untied from the
+ * HTTP layer and any future non-HTTP caller. Emits `updated`.
+ */
+export async function updateAnnouncement(
+  state: AnnouncementProcessState,
+  editor: { id: string; role: "board" | "admin" },
+  patch: AnnouncementContentPatch,
+  ctx: AnnouncementProcessContext,
+): Promise<AnnouncementActionOutcome> {
+  if (!canEdit(state, editor.id, editor.role)) {
+    throw new Error("Not authorized to edit this announcement.");
+  }
+
+  const editedFields: Array<"title" | "body" | "links"> = [];
+  const nextContent: AnnouncementContent = { ...state.content };
+
+  if (patch.title !== undefined && patch.title !== state.content.title) {
+    nextContent.title = patch.title;
+    editedFields.push("title");
+  }
+  if (patch.body !== undefined && patch.body !== state.content.body) {
+    nextContent.body = patch.body;
+    editedFields.push("body");
+  }
+  if (patch.links !== undefined) {
+    nextContent.links = patch.links;
+    // Compare stringified to detect actual change; keeps the event honest.
+    if (JSON.stringify(patch.links) !== JSON.stringify(state.content.links)) {
+      editedFields.push("links");
+    }
+  }
+
+  if (editedFields.length === 0) {
+    // No-op edit — don't emit a spurious `updated` event.
+    return { state, result: { edited_fields: [] } };
+  }
+
+  state.content = sanitizeContent(nextContent);
+  state.last_edited_at = new Date().toISOString();
+  state.edit_count += 1;
+
+  await emitAnnouncementUpdated(ctx, editor.id, state, editedFields);
+
+  return {
+    state,
+    result: {
+      edited_fields: editedFields,
+      edit_count: state.edit_count,
+      last_edited_at: state.last_edited_at,
+    },
+  };
+}
+
+function sanitizeContent(c: AnnouncementContent): AnnouncementContent {
+  const title = (c.title ?? "").trim();
+  if (title.length === 0) {
+    throw new Error("Announcement title is required.");
+  }
+  if (title.length > TITLE_MAX) {
+    throw new Error(`Announcement title must be <= ${TITLE_MAX} characters.`);
+  }
+
+  const body = (c.body ?? "").trim();
+  if (body.length === 0) {
+    throw new Error("Announcement body is required.");
+  }
+  if (body.length > BODY_MAX) {
+    throw new Error(`Announcement body must be <= ${BODY_MAX} characters.`);
+  }
+
+  const rawLinks = Array.isArray(c.links) ? c.links : [];
+  if (rawLinks.length > LINKS_MAX) {
+    throw new Error(`At most ${LINKS_MAX} links per announcement.`);
+  }
+  const links: AnnouncementLink[] = [];
+  for (const l of rawLinks) {
+    const label = (l?.label ?? "").trim();
+    const url = (l?.url ?? "").trim();
+    if (label.length === 0 && url.length === 0) continue; // silently skip empty rows
+    if (label.length === 0 || url.length === 0) {
+      throw new Error("Each link requires both a label and a URL.");
+    }
+    if (label.length > LINK_LABEL_MAX) {
+      throw new Error(`Link label must be <= ${LINK_LABEL_MAX} characters.`);
+    }
+    if (url.length > LINK_URL_MAX) {
+      throw new Error(`Link URL must be <= ${LINK_URL_MAX} characters.`);
+    }
+    if (!/^https?:\/\//i.test(url)) {
+      throw new Error(`Link URL must start with http:// or https://: ${url}`);
+    }
+    links.push({ label, url });
+  }
+
+  return { title, body, links };
+}
+
+/** Public read model — what GET /announcement/:id returns. */
+export function getPublicReadModel(
+  state: AnnouncementProcessState,
+  processMeta: { id: string; createdAt: string },
+): Record<string, unknown> {
+  return {
+    id: processMeta.id,
+    type: "civic.announcement",
+    title: state.content.title,
+    body: state.content.body,
+    links: state.content.links,
+    author_id: state.author_id,
+    author_role: state.author_role,
+    created_at: state.created_at,
+    last_edited_at: state.last_edited_at,
+    edit_count: state.edit_count,
+  };
+}
+
+/** Summary used by GET /announcements list. */
+export function getPublicSummary(
+  state: AnnouncementProcessState,
+  processMeta: { id: string; createdAt: string },
+): Record<string, unknown> {
+  return {
+    id: processMeta.id,
+    type: "civic.announcement",
+    title: state.content.title,
+    author_role: state.author_role,
+    created_at: state.created_at,
+    last_edited_at: state.last_edited_at,
+    edit_count: state.edit_count,
+  };
+}

--- a/src/processes/announcementProcess.ts
+++ b/src/processes/announcementProcess.ts
@@ -1,0 +1,79 @@
+// civic.announcement process handler — thin adapter around the module.
+//
+// Announcements are not driven through the generic /process/:id/action
+// dispatcher. The admin HTTP surface (/announcement/*) orchestrates the
+// create / edit lifecycle directly via the module's service functions.
+// This adapter exists so announcements live in the same process store
+// and register as a known process type for discovery / feed rendering.
+
+import { Process, ProcessAction } from "../models/process.js";
+import { ProcessHandler } from "./types.js";
+import {
+  createAnnouncementState,
+  getPublicReadModel,
+  getPublicSummary,
+  type AnnouncementAuthorRole,
+  type AnnouncementLink,
+  type AnnouncementProcessState,
+  type CreateAnnouncementInput,
+} from "../modules/civic.announcement/index.js";
+
+function getState(process: Process): AnnouncementProcessState {
+  return process.state as unknown as AnnouncementProcessState;
+}
+
+const announcementProcess: ProcessHandler = {
+  type: "civic.announcement",
+
+  initializeState(input: Record<string, unknown>): Record<string, unknown> {
+    // Expected shape mirrors CreateAnnouncementInput. The hub's announcement
+    // controller is the only caller; any other path is an error.
+    const required = ["title", "body", "author_id", "author_role"] as const;
+    for (const key of required) {
+      if (!(key in input)) {
+        throw new Error(
+          `civic.announcement initializeState requires "${key}"`,
+        );
+      }
+    }
+    const createInput: CreateAnnouncementInput = {
+      title: input.title as string,
+      body: input.body as string,
+      author_id: input.author_id as string,
+      author_role: input.author_role as AnnouncementAuthorRole,
+      links: Array.isArray(input.links)
+        ? (input.links as AnnouncementLink[])
+        : undefined,
+    };
+    return createAnnouncementState(createInput) as unknown as Record<string, unknown>;
+  },
+
+  async handleAction(
+    _process: Process,
+    action: ProcessAction,
+  ): Promise<Record<string, unknown>> {
+    // No HTTP actions reach announcements via the generic dispatcher.
+    throw new Error(
+      `civic.announcement does not accept process actions (received "${action.type}"). ` +
+        `Create / edit happens via /announcement HTTP endpoints.`,
+    );
+  },
+
+  getReadModel(process: Process): Record<string, unknown> {
+    const state = getState(process);
+    return getPublicReadModel(state, {
+      id: process.id,
+      createdAt: process.createdAt,
+    });
+  },
+
+  getSummary(process: Process): Record<string, unknown> {
+    const state = getState(process);
+    return getPublicSummary(state, {
+      id: process.id,
+      createdAt: process.createdAt,
+    });
+  },
+};
+
+export default announcementProcess;

--- a/src/processes/registry.ts
+++ b/src/processes/registry.ts
@@ -8,15 +8,19 @@ import { ProcessHandler, ProcessFactory } from "./types.js";
 import voteProcess from "./voteProcess.js";
 import proposalProcess from "./proposalProcess.js";
 import briefProcess from "./briefProcess.js";
+import announcementProcess from "./announcementProcess.js";
 
-// civic.brief is registered here but can be omitted by hubs that don't want
-// brief generation. When present, the vote adapter's process.close handler
-// spawns a brief after the vote closes. When absent, vote closes simply
-// terminate without a brief.
+// civic.brief + civic.announcement are registered here but can be omitted
+// by hubs that don't want those capabilities. When civic.brief is present,
+// the vote adapter spawns a brief on close; when absent, vote closes
+// terminate without a brief. civic.announcement is entirely self-contained
+// via /announcement routes — a hub without it just 404s those URLs and
+// nothing else breaks.
 const processRegistry: Record<string, ProcessHandler> = {
   "civic.vote": voteProcess,
   "civic.proposal": proposalProcess,
   "civic.brief": briefProcess,
+  "civic.announcement": announcementProcess,
 };
 
 /**

--- a/src/routes/announcementRoutes.ts
+++ b/src/routes/announcementRoutes.ts
@@ -1,0 +1,23 @@
+// Announcement routes.
+//
+// POST /announcement          — create (Board or admin)
+// PATCH /announcement/:id     — edit (author-only unless admin)
+// GET /announcement/:id       — public read
+// GET /announcements          — public list (handled via a separate router
+//                                mount; see app.ts)
+
+import { Router } from "express";
+import {
+  handleCreateAnnouncement,
+  handleGetAnnouncement,
+  handleUpdateAnnouncement,
+} from "../controllers/announcementController.js";
+import { requireBoardOrAdmin } from "../middleware/auth.js";
+
+const router = Router();
+
+router.post("/", requireBoardOrAdmin, handleCreateAnnouncement);
+router.patch("/:id", requireBoardOrAdmin, handleUpdateAnnouncement);
+router.get("/:id", handleGetAnnouncement);
+
+export default router;

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -13,6 +13,8 @@ import AdminProposals from "./pages/AdminProposals";
 import AdminBriefs from "./pages/AdminBriefs";
 import Brief from "./pages/Brief";
 import VoteLog from "./pages/VoteLog";
+import PostAnnouncement from "./pages/PostAnnouncement";
+import AnnouncementPage from "./pages/Announcement";
 import IntroPopup, { hasSeenIntro } from "./components/IntroPopup";
 import "./App.css";
 
@@ -48,6 +50,9 @@ function AppContent() {
           <Route path="/admin/proposals" element={<AdminProposals />} />
           <Route path="/admin/briefs" element={<AdminBriefs />} />
           <Route path="/brief/:id" element={<Brief />} />
+          <Route path="/announcement/new" element={<PostAnnouncement />} />
+          <Route path="/announcement/:id/edit" element={<PostAnnouncement />} />
+          <Route path="/announcement/:id" element={<AnnouncementPage />} />
           <Route path="/about" element={<About />} />
         </Routes>
       </main>

--- a/ui/src/components/AuthModal.tsx
+++ b/ui/src/components/AuthModal.tsx
@@ -78,7 +78,7 @@ export default function AuthModal({ onComplete, onDismiss }: Props) {
     setLoading(true);
     try {
       const result = await verifyCode(email.trim(), code.trim());
-      login(result.token, result.user);
+      login(result.token, result.user, result.role);
 
       if (result.user.is_resident) {
         // Already a resident (returning user) — done

--- a/ui/src/components/Feed.tsx
+++ b/ui/src/components/Feed.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import {
   type CivicEvent,
   type VoteState,
+  getAnnouncement,
   getEvents,
   getProcessState,
   getPublicBrief,
@@ -20,7 +21,7 @@ interface Props {
   filter?: (event: CivicEvent) => boolean;
 }
 
-type ProcessKind = "civic.vote" | "civic.brief";
+type ProcessKind = "civic.vote" | "civic.brief" | "civic.announcement";
 
 interface ProcessMeta {
   type?: ProcessKind;
@@ -31,13 +32,18 @@ interface ProcessMeta {
 /**
  * Discriminate the underlying process type for an event from its data.
  * - civic.process.started is only emitted by civic.vote today.
- * - civic.process.result_published carries `brief_id` on brief emissions
- *   and `result` (with `tally`) on vote emissions.
+ * - civic.process.result_published is emitted by all three process types;
+ *   we use the event's data shape to tell them apart.
  */
 function kindFromEvent(event: CivicEvent): ProcessKind | null {
   if (event.event_type === "civic.process.started") return "civic.vote";
   if (event.event_type === "civic.process.result_published") {
-    const data = event.data as { brief_id?: unknown; result?: unknown };
+    const data = event.data as {
+      brief_id?: unknown;
+      result?: unknown;
+      announcement?: unknown;
+    };
+    if (data?.announcement !== undefined) return "civic.announcement";
     if (typeof data?.brief_id === "string") return "civic.brief";
     if (data?.result !== undefined) return "civic.vote";
   }
@@ -100,18 +106,31 @@ export default function Feed({ filter }: Props) {
     for (const { id } of needed) inFlight.current.add(id);
 
     for (const { id, kind } of needed) {
-      const lookup =
-        kind === "civic.vote"
-          ? getProcessState(id).then((state) => {
-              if (state.type !== "civic.vote") return null;
-              const vote = state as VoteState;
-              return { type: "civic.vote" as const, title: vote.title, description: vote.description };
-            })
-          : getPublicBrief(id).then((brief) => ({
-              type: "civic.brief" as const,
-              title: brief.title,
-              description: undefined,
-            }));
+      let lookup: Promise<ProcessMeta | null>;
+      if (kind === "civic.vote") {
+        lookup = getProcessState(id).then((state) => {
+          if (state.type !== "civic.vote") return null;
+          const vote = state as VoteState;
+          return {
+            type: "civic.vote" as const,
+            title: vote.title,
+            description: vote.description,
+          };
+        });
+      } else if (kind === "civic.brief") {
+        lookup = getPublicBrief(id).then((brief) => ({
+          type: "civic.brief" as const,
+          title: brief.title,
+          description: undefined,
+        }));
+      } else {
+        // civic.announcement — body serves as the feed summary.
+        lookup = getAnnouncement(id).then((a) => ({
+          type: "civic.announcement" as const,
+          title: a.title,
+          description: a.body,
+        }));
+      }
 
       lookup
         .then((meta) => {

--- a/ui/src/components/FeedPost.tsx
+++ b/ui/src/components/FeedPost.tsx
@@ -25,18 +25,20 @@ interface Props {
  * The filter map is open for extension: new process-type plugins can be
  * surfaced by adding entries here without restructuring the Feed.
  */
+type FeedProcessKind = "civic.vote" | "civic.brief" | "civic.announcement";
+
 export function eventToPost(
   event: CivicEvent,
   getProcessDescription: (processId: string) => string | undefined,
   getProcessTitle: (processId: string) => string | undefined,
-  getProcessType: (processId: string) => "civic.vote" | "civic.brief" | undefined,
+  getProcessType: (processId: string) => FeedProcessKind | undefined,
 ): FeedPostView | null {
   switch (event.event_type) {
     case "civic.process.started": {
       // `started` fires when a process enters active participation. Today
       // only civic.vote emits this event; render as "New vote: …". When
       // additional process types start emitting `started` (petitions,
-      // announcements, etc.), branch here by the cached process type.
+      // etc.), branch here by the cached process type.
       const title = getProcessTitle(event.process_id) ?? "Untitled vote";
       return {
         id: event.id,
@@ -48,20 +50,45 @@ export function eventToPost(
     }
 
     case "civic.process.result_published": {
-      // Discriminate vote vs brief. Vote results publish "Vote results
-      // published: [title]"; briefs publish "Civic Brief delivered: [title]"
-      // and link to the public /brief/:id page. Briefs' action_url already
-      // points at /brief/:id via the backend's action_url_path override.
+      // Discriminate across the three process types that emit this event.
+      // Primary discriminator is the event's own data shape; fallback is
+      // the cached process type from GET /process/:id.
       const data = event.data as {
         brief_id?: string;
         result?: { total_votes?: number };
         participation_count?: number;
         headline_result?: string;
+        announcement?: {
+          id?: string;
+          title?: string;
+          author_role?: "board" | "admin";
+        };
       };
 
+      const cachedType = getProcessType(event.process_id);
+
+      // Announcement result_published
+      if (data.announcement || cachedType === "civic.announcement") {
+        const title =
+          data.announcement?.title ??
+          getProcessTitle(event.process_id) ??
+          "Announcement";
+        const role = data.announcement?.author_role;
+        const label = role === "admin" ? "Announcement" : "Board announcement";
+        return {
+          id: event.id,
+          title: `${label}: ${title}`,
+          summary: summaryFromDescription(
+            getProcessDescription(event.process_id),
+          ),
+          timestamp: event.timestamp,
+          href: event.action_url,
+        };
+      }
+
+      // Civic Brief result_published
       const isBrief =
-        typeof data.brief_id === "string" ||
-        getProcessType(event.process_id) === "civic.brief";
+        typeof data.brief_id === "string" || cachedType === "civic.brief";
 
       if (isBrief) {
         const title = getProcessTitle(event.process_id) ?? "Civic Brief";
@@ -79,6 +106,7 @@ export function eventToPost(
         };
       }
 
+      // Vote result_published
       const total = data.result?.total_votes ?? 0;
       const title =
         getProcessTitle(event.process_id) ?? `Process ${event.process_id}`;
@@ -158,6 +186,9 @@ function classifyHref(href: string): { kind: "internal"; to: string } | { kind: 
       return { kind: "internal", to: url.pathname };
     }
     if (/^\/brief\/[^/]+\/?$/.test(url.pathname)) {
+      return { kind: "internal", to: url.pathname };
+    }
+    if (/^\/announcement\/[^/]+\/?$/.test(url.pathname)) {
       return { kind: "internal", to: url.pathname };
     }
     if (url.origin === window.location.origin) {

--- a/ui/src/components/Nav.tsx
+++ b/ui/src/components/Nav.tsx
@@ -2,11 +2,8 @@ import { NavLink } from "react-router-dom";
 import { useAuth } from "../context/AuthContext";
 import "./Nav.css";
 
-const ADMIN_EMAIL = "creatinglake@gmail.com";
-
 export default function Nav() {
-  const { user, logout } = useAuth();
-  const isAdmin = user?.email === ADMIN_EMAIL;
+  const { user, logout, isAdmin, canPostAnnouncements } = useAuth();
 
   return (
     <nav className="civic-nav" aria-label="Primary">
@@ -28,6 +25,16 @@ export default function Nav() {
         </li>
       </ul>
       <div className="civic-nav-right">
+        {canPostAnnouncements && (
+          <NavLink
+            to="/announcement/new"
+            className={({ isActive }) =>
+              `civic-nav-link civic-nav-link-post${isActive ? " is-active" : ""}`
+            }
+          >
+            Post Announcement
+          </NavLink>
+        )}
         {isAdmin && (
           <NavLink
             to="/admin/proposals"

--- a/ui/src/context/AuthContext.tsx
+++ b/ui/src/context/AuthContext.tsx
@@ -2,6 +2,7 @@ import { createContext, useContext, useState, useEffect, useCallback } from "rea
 import type { ReactNode } from "react";
 import {
   type AuthUser,
+  type AuthRole,
   getStoredToken,
   storeToken,
   clearToken,
@@ -17,8 +18,18 @@ interface AuthState {
   actorId: string | null;
   /** Whether the user is fully ready to participate (authenticated + resident) */
   canParticipate: boolean;
+  /**
+   * Elevated role derived server-side from CIVIC_ADMIN_EMAILS /
+   * CIVIC_BOARD_EMAILS. null for residents without special privileges.
+   * Admins can do everything Board members can plus admin-panel access.
+   */
+  role: AuthRole;
+  /** Convenience: true when role is "admin". */
+  isAdmin: boolean;
+  /** Convenience: true when role is "admin" OR "board". */
+  canPostAnnouncements: boolean;
   /** Login with a token and user from the verify step */
-  login: (token: string, user: AuthUser) => void;
+  login: (token: string, user: AuthUser, role?: AuthRole) => void;
   /** Update user after residency affirmation */
   updateUser: (user: AuthUser) => void;
   /** Logout and clear session */
@@ -30,6 +41,7 @@ const AuthContext = createContext<AuthState | null>(null);
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<AuthUser | null>(null);
   const [token, setToken] = useState<string | null>(null);
+  const [role, setRole] = useState<AuthRole>(null);
   const [loading, setLoading] = useState(true);
 
   // Try to restore session from localStorage on mount
@@ -37,8 +49,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const stored = getStoredToken();
     if (stored) {
       getMe(stored)
-        .then(({ user: u }) => {
+        .then(({ user: u, role: r }) => {
           setUser(u);
+          setRole(r ?? null);
           setToken(stored);
         })
         .catch(() => {
@@ -51,11 +64,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
   }, []);
 
-  const login = useCallback((newToken: string, newUser: AuthUser) => {
-    storeToken(newToken);
-    setToken(newToken);
-    setUser(newUser);
-  }, []);
+  const login = useCallback(
+    (newToken: string, newUser: AuthUser, newRole: AuthRole = null) => {
+      storeToken(newToken);
+      setToken(newToken);
+      setUser(newUser);
+      setRole(newRole);
+    },
+    [],
+  );
 
   const updateUser = useCallback((updatedUser: AuthUser) => {
     setUser(updatedUser);
@@ -68,14 +85,29 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     clearToken();
     setToken(null);
     setUser(null);
+    setRole(null);
   }, [token]);
 
   const actorId = user?.id ?? null;
   const canParticipate = !!user && user.email_verified && user.is_resident;
+  const isAdmin = role === "admin";
+  const canPostAnnouncements = role === "admin" || role === "board";
 
   return (
     <AuthContext.Provider
-      value={{ user, token, loading, actorId, canParticipate, login, updateUser, logout }}
+      value={{
+        user,
+        token,
+        loading,
+        actorId,
+        canParticipate,
+        role,
+        isAdmin,
+        canPostAnnouncements,
+        login,
+        updateUser,
+        logout,
+      }}
     >
       {children}
     </AuthContext.Provider>

--- a/ui/src/pages/Announcement.css
+++ b/ui/src/pages/Announcement.css
@@ -1,0 +1,101 @@
+.announcement-page {
+  padding: var(--space-lg);
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+.announcement-status {
+  color: var(--color-text-subtle);
+  font-family: var(--font-body);
+  font-size: var(--font-size-base);
+  text-align: center;
+  padding: var(--space-xl) var(--space-md);
+}
+
+.announcement-status-error {
+  color: var(--color-text);
+}
+
+.announcement-header {
+  margin: 0 0 var(--space-xl);
+}
+
+.announcement-eyebrow {
+  margin: 0;
+  color: var(--color-brand);
+  font-family: var(--font-heading);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.announcement-header h1 {
+  margin: var(--space-xs) 0 var(--space-sm);
+  font-size: var(--font-size-xl);
+  line-height: var(--line-height-tight);
+}
+
+.announcement-meta {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-base);
+}
+
+.announcement-edit-link {
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+.announcement-edit-link:hover {
+  text-decoration: underline;
+}
+
+.announcement-body {
+  margin: 0 0 var(--space-xl);
+  font-size: var(--font-size-base);
+  line-height: var(--line-height-base);
+  color: var(--color-text);
+}
+
+.announcement-paragraph {
+  margin: 0 0 var(--space-md);
+  white-space: pre-wrap;
+}
+
+.announcement-paragraph:last-child {
+  margin-bottom: 0;
+}
+
+.announcement-links {
+  padding: var(--space-md) var(--space-lg);
+  background: var(--color-surface-muted);
+  border-radius: var(--radius-md);
+}
+
+.announcement-links h2 {
+  margin: 0 0 var(--space-sm);
+  font-family: var(--font-heading);
+  font-size: var(--font-size-base);
+  color: var(--color-text);
+}
+
+.announcement-links ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.announcement-links li {
+  margin-bottom: var(--space-xs);
+}
+
+.announcement-links a {
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+.announcement-links a:hover {
+  text-decoration: underline;
+}

--- a/ui/src/pages/Announcement.tsx
+++ b/ui/src/pages/Announcement.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import { getAnnouncement, type Announcement } from "../services/api";
+import { useAuth } from "../context/AuthContext";
+import "./Announcement.css";
+
+export default function AnnouncementPage() {
+  const { id } = useParams<{ id: string }>();
+  const { user, isAdmin } = useAuth();
+
+  const [announcement, setAnnouncement] = useState<Announcement | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!id) return;
+    let cancelled = false;
+    setLoading(true);
+    getAnnouncement(id)
+      .then((a) => {
+        if (cancelled) return;
+        setAnnouncement(a);
+      })
+      .catch((err: Error) => {
+        if (cancelled) return;
+        setError(err.message);
+      })
+      .finally(() => {
+        if (cancelled) return;
+        setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+
+  if (loading) {
+    return (
+      <div className="page announcement-page">
+        <p className="announcement-status">Loading announcement…</p>
+      </div>
+    );
+  }
+
+  if (error || !announcement) {
+    return (
+      <div className="page announcement-page">
+        <Link to="/" className="back-link">
+          &larr; Home
+        </Link>
+        <p className="announcement-status announcement-status-error">
+          {error ?? "Announcement not found."}
+        </p>
+      </div>
+    );
+  }
+
+  const roleLabel =
+    announcement.author_role === "board" ? "Board member" : "Admin";
+  const canEdit =
+    isAdmin || (!!user?.id && user.id === announcement.author_id);
+  const wasEdited = announcement.edit_count > 0;
+
+  return (
+    <article className="page announcement-page">
+      <Link to="/" className="back-link">
+        &larr; Home
+      </Link>
+      <header className="announcement-header">
+        <p className="announcement-eyebrow">
+          {announcement.author_role === "board"
+            ? "Board announcement"
+            : "Announcement"}
+        </p>
+        <h1>{announcement.title}</h1>
+        <p className="announcement-meta">
+          Posted by {roleLabel} on{" "}
+          <time dateTime={announcement.created_at}>
+            {formatDate(announcement.created_at)}
+          </time>
+          {wasEdited && announcement.last_edited_at && (
+            <>
+              {" · Last edited "}
+              <time dateTime={announcement.last_edited_at}>
+                {formatDate(announcement.last_edited_at)}
+              </time>
+            </>
+          )}
+          {canEdit && (
+            <>
+              {" · "}
+              <Link
+                to={`/announcement/${announcement.id}/edit`}
+                className="announcement-edit-link"
+              >
+                Edit
+              </Link>
+            </>
+          )}
+        </p>
+      </header>
+
+      <div className="announcement-body">
+        {announcement.body.split(/\n\n+/).map((para, i) => (
+          <p key={i} className="announcement-paragraph">
+            {para.split(/\n/).map((line, j, arr) => (
+              <span key={j}>
+                {line}
+                {j < arr.length - 1 && <br />}
+              </span>
+            ))}
+          </p>
+        ))}
+      </div>
+
+      {announcement.links.length > 0 && (
+        <section className="announcement-links">
+          <h2>Links</h2>
+          <ul>
+            {announcement.links.map((link, i) => (
+              <li key={i}>
+                <a href={link.url} target="_blank" rel="noopener noreferrer">
+                  {link.label}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+    </article>
+  );
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}

--- a/ui/src/pages/PostAnnouncement.css
+++ b/ui/src/pages/PostAnnouncement.css
@@ -1,0 +1,105 @@
+.post-announcement-page {
+  padding: var(--space-lg);
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+.post-announcement-page h1 {
+  margin: 0 0 var(--space-sm);
+}
+
+.post-announcement-status {
+  color: var(--color-text-subtle);
+  font-family: var(--font-body);
+  font-size: var(--font-size-base);
+  text-align: center;
+  padding: var(--space-xl) var(--space-md);
+}
+
+.post-announcement-lede {
+  margin: 0 0 var(--space-lg);
+  color: var(--color-text-muted);
+  line-height: var(--line-height-base);
+}
+
+.post-announcement-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+}
+
+.form-counter {
+  align-self: flex-end;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-subtle);
+  margin-top: calc(var(--space-xs) * -1);
+}
+
+.announcement-link-row {
+  display: grid;
+  grid-template-columns: 1fr 2fr auto;
+  gap: var(--space-sm);
+  margin-bottom: var(--space-sm);
+  align-items: center;
+}
+
+.announcement-link-remove {
+  width: 2rem;
+  height: 2rem;
+  background: none;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-lg);
+  line-height: 1;
+  cursor: pointer;
+  color: var(--color-text-subtle);
+}
+
+.announcement-link-remove:hover:not(:disabled) {
+  color: var(--color-text);
+  border-color: var(--color-border-hover);
+}
+
+.announcement-link-add {
+  background: none;
+  border: 1px dashed var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-sm) var(--space-md);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  font-family: var(--font-body);
+  font-size: var(--font-size-sm);
+  align-self: flex-start;
+}
+
+.announcement-link-add:hover:not(:disabled) {
+  color: var(--color-text);
+  border-color: var(--color-border-hover);
+}
+
+.post-announcement-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.post-announcement-submit {
+  padding: var(--space-sm) var(--space-lg);
+  background: var(--color-primary);
+  color: var(--color-primary-text);
+  border: none;
+  border-radius: var(--radius-sm);
+  font-family: var(--font-body);
+  font-size: var(--font-size-base);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.post-announcement-submit:hover:not(:disabled) {
+  background: var(--color-primary-hover);
+}
+
+.post-announcement-submit:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/ui/src/pages/PostAnnouncement.tsx
+++ b/ui/src/pages/PostAnnouncement.tsx
@@ -1,0 +1,274 @@
+import { useEffect, useState } from "react";
+import { Link, useNavigate, useParams } from "react-router-dom";
+import {
+  createAnnouncement,
+  getAnnouncement,
+  updateAnnouncement,
+  type AnnouncementLink,
+} from "../services/api";
+import { useAuth } from "../context/AuthContext";
+import "./PostAnnouncement.css";
+
+const TITLE_MAX = 200;
+const BODY_MAX = 5000;
+const LINKS_MAX = 5;
+
+export default function PostAnnouncement() {
+  const navigate = useNavigate();
+  const { id: editId } = useParams<{ id?: string }>();
+  const { role, canPostAnnouncements, loading: authLoading, user } = useAuth();
+
+  const isEditMode = Boolean(editId);
+
+  const [title, setTitle] = useState("");
+  const [body, setBody] = useState("");
+  const [links, setLinks] = useState<AnnouncementLink[]>([]);
+  const [loadingExisting, setLoadingExisting] = useState(isEditMode);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [authorId, setAuthorId] = useState<string | null>(null);
+
+  // Load the existing announcement when editing.
+  useEffect(() => {
+    if (!editId) return;
+    setLoadingExisting(true);
+    getAnnouncement(editId)
+      .then((a) => {
+        setTitle(a.title);
+        setBody(a.body);
+        setLinks(a.links);
+        setAuthorId(a.author_id);
+      })
+      .catch((err: Error) => setError(err.message))
+      .finally(() => setLoadingExisting(false));
+  }, [editId]);
+
+  // Gate: only Board or admin can reach the form at all. On edit, only the
+  // original author or an admin can reach the form. Residents and
+  // unauthenticated users get a clear message with a link home.
+  if (authLoading) {
+    return (
+      <div className="page post-announcement-page">
+        <p className="post-announcement-status">Loading…</p>
+      </div>
+    );
+  }
+
+  if (!canPostAnnouncements) {
+    return (
+      <div className="page post-announcement-page">
+        <Link to="/" className="back-link">
+          &larr; Home
+        </Link>
+        <h1>Not available</h1>
+        <p>
+          Only Board members and admins can post announcements. If you believe
+          this is a mistake, contact the hub administrator.
+        </p>
+      </div>
+    );
+  }
+
+  if (isEditMode) {
+    if (loadingExisting) {
+      return (
+        <div className="page post-announcement-page">
+          <p className="post-announcement-status">Loading announcement…</p>
+        </div>
+      );
+    }
+    const isAdmin = role === "admin";
+    const isOwner = user?.id && authorId && user.id === authorId;
+    if (!isAdmin && !isOwner) {
+      return (
+        <div className="page post-announcement-page">
+          <Link to={`/announcement/${editId}`} className="back-link">
+            &larr; Back to announcement
+          </Link>
+          <h1>Not your announcement</h1>
+          <p>
+            Board members can only edit announcements they posted. If a
+            correction is needed, ask an admin.
+          </p>
+        </div>
+      );
+    }
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+
+    const cleanedLinks = links
+      .map((l) => ({ label: l.label.trim(), url: l.url.trim() }))
+      .filter((l) => l.label.length > 0 || l.url.length > 0);
+
+    setSubmitting(true);
+    try {
+      if (isEditMode && editId) {
+        await updateAnnouncement(editId, {
+          title: title.trim(),
+          body: body.trim(),
+          links: cleanedLinks,
+        });
+        navigate(`/announcement/${editId}`);
+      } else {
+        const created = await createAnnouncement({
+          title: title.trim(),
+          body: body.trim(),
+          links: cleanedLinks,
+        });
+        navigate(`/announcement/${created.id}`);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Submission failed");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  function updateLink(i: number, patch: Partial<AnnouncementLink>) {
+    setLinks((cur) =>
+      cur.map((l, idx) => (idx === i ? { ...l, ...patch } : l)),
+    );
+  }
+
+  function addLink() {
+    if (links.length >= LINKS_MAX) return;
+    setLinks((cur) => [...cur, { label: "", url: "" }]);
+  }
+
+  function removeLink(i: number) {
+    setLinks((cur) => cur.filter((_, idx) => idx !== i));
+  }
+
+  const titleOver = title.length > TITLE_MAX;
+  const bodyOver = body.length > BODY_MAX;
+  const canSubmit =
+    title.trim().length > 0 &&
+    body.trim().length > 0 &&
+    !titleOver &&
+    !bodyOver &&
+    !submitting;
+
+  return (
+    <div className="page post-announcement-page">
+      <Link
+        to={isEditMode && editId ? `/announcement/${editId}` : "/"}
+        className="back-link"
+      >
+        &larr; {isEditMode ? "Back to announcement" : "Home"}
+      </Link>
+      <h1>{isEditMode ? "Edit announcement" : "Post an announcement"}</h1>
+      <p className="post-announcement-lede">
+        {isEditMode
+          ? "Changes are logged. The announcement page will show an \"edited\" timestamp."
+          : "Announcements publish immediately and appear in the public feed. One-way — residents can read but not reply."}
+      </p>
+
+      <form onSubmit={handleSubmit} className="post-announcement-form">
+        <div className="form-field">
+          <label className="form-label" htmlFor="announcement-title">
+            Title <span className="required">*</span>
+          </label>
+          <input
+            id="announcement-title"
+            className="form-input"
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value.slice(0, TITLE_MAX))}
+            maxLength={TITLE_MAX}
+            placeholder="Short, specific — e.g. 'Regular meeting moved to April 29'"
+            disabled={submitting}
+          />
+          <span className="form-counter">
+            {title.length} / {TITLE_MAX}
+          </span>
+        </div>
+
+        <div className="form-field">
+          <label className="form-label" htmlFor="announcement-body">
+            Body <span className="required">*</span>
+          </label>
+          <textarea
+            id="announcement-body"
+            className="form-textarea"
+            value={body}
+            onChange={(e) => setBody(e.target.value.slice(0, BODY_MAX))}
+            maxLength={BODY_MAX}
+            rows={10}
+            placeholder="Plain text. Line breaks are preserved. Add links below as separate label + URL rows."
+            disabled={submitting}
+          />
+          <span className="form-counter">
+            {body.length} / {BODY_MAX}
+          </span>
+        </div>
+
+        <div className="form-field">
+          <label className="form-label">Links <span className="optional">(optional)</span></label>
+          <p className="form-hint">
+            Up to {LINKS_MAX} labeled links appear below the announcement body.
+          </p>
+          {links.map((link, i) => (
+            <div key={i} className="announcement-link-row">
+              <input
+                className="form-input"
+                type="text"
+                value={link.label}
+                onChange={(e) => updateLink(i, { label: e.target.value })}
+                placeholder="Link label"
+                disabled={submitting}
+              />
+              <input
+                className="form-input"
+                type="url"
+                value={link.url}
+                onChange={(e) => updateLink(i, { url: e.target.value })}
+                placeholder="https://…"
+                disabled={submitting}
+              />
+              <button
+                type="button"
+                className="announcement-link-remove"
+                onClick={() => removeLink(i)}
+                disabled={submitting}
+                aria-label={`Remove link ${i + 1}`}
+              >
+                ×
+              </button>
+            </div>
+          ))}
+          {links.length < LINKS_MAX && (
+            <button
+              type="button"
+              className="announcement-link-add"
+              onClick={addLink}
+              disabled={submitting}
+            >
+              + Add link
+            </button>
+          )}
+        </div>
+
+        {error && <p className="form-error">{error}</p>}
+
+        <div className="post-announcement-actions">
+          <button
+            type="submit"
+            className="post-announcement-submit"
+            disabled={!canSubmit}
+          >
+            {submitting
+              ? isEditMode
+                ? "Saving…"
+                : "Posting…"
+              : isEditMode
+                ? "Save changes"
+                : "Post announcement"}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/ui/src/services/api.ts
+++ b/ui/src/services/api.ts
@@ -515,6 +515,74 @@ export function getPublicBrief(id: string): Promise<PublicBrief> {
   return request("GET", `/brief/${id}`);
 }
 
+// --- Announcements ---
+
+export type AnnouncementAuthorRole = "board" | "admin";
+
+export interface AnnouncementLink {
+  label: string;
+  url: string;
+}
+
+/** Full read of one announcement (GET /announcement/:id). */
+export interface Announcement {
+  id: string;
+  type: "civic.announcement";
+  title: string;
+  body: string;
+  links: AnnouncementLink[];
+  author_id: string;
+  author_role: AnnouncementAuthorRole;
+  created_at: string;
+  last_edited_at: string | null;
+  edit_count: number;
+}
+
+/** Summary row (GET /announcements). */
+export interface AnnouncementSummary {
+  id: string;
+  type: "civic.announcement";
+  title: string;
+  author_role: AnnouncementAuthorRole;
+  created_at: string;
+  last_edited_at: string | null;
+  edit_count: number;
+}
+
+export interface CreateAnnouncementInput {
+  title: string;
+  body: string;
+  links?: AnnouncementLink[];
+}
+
+export interface UpdateAnnouncementInput {
+  title?: string;
+  body?: string;
+  links?: AnnouncementLink[];
+}
+
+export function createAnnouncement(
+  input: CreateAnnouncementInput,
+): Promise<Announcement> {
+  return request("POST", "/announcement", input);
+}
+
+export function updateAnnouncement(
+  id: string,
+  input: UpdateAnnouncementInput,
+): Promise<Announcement> {
+  return request("PATCH", `/announcement/${id}`, input);
+}
+
+export function getAnnouncement(id: string): Promise<Announcement> {
+  return request("GET", `/announcement/${id}`);
+}
+
+export function listAnnouncements(limit?: number): Promise<AnnouncementSummary[]> {
+  const q = typeof limit === "number" ? `?limit=${limit}` : "";
+  return request("GET", `/announcements${q}`);
+}
+
 // --- Admin: hub settings ---
 
 export interface AdminSettings {

--- a/ui/src/services/auth.ts
+++ b/ui/src/services/auth.ts
@@ -35,6 +35,13 @@ export interface AuthUser {
   created_at: string;
 }
 
+/**
+ * Elevated role for the authenticated user, derived server-side from
+ * CIVIC_ADMIN_EMAILS / CIVIC_BOARD_EMAILS env vars. null for residents
+ * with no special privileges.
+ */
+export type AuthRole = "admin" | "board" | null;
+
 // --- Token storage ---
 
 const TOKEN_KEY = "civic_auth_token";
@@ -60,7 +67,7 @@ export function requestCode(email: string): Promise<{ message: string }> {
 export function verifyCode(
   email: string,
   code: string
-): Promise<{ token: string; user: AuthUser }> {
+): Promise<{ token: string; user: AuthUser; role: AuthRole }> {
   return request("POST", "/auth/verify", { email, code });
 }
 
@@ -68,7 +75,7 @@ export function affirmResidency(token: string): Promise<{ user: AuthUser }> {
   return request("POST", "/auth/residency", undefined, token);
 }
 
-export function getMe(token: string): Promise<{ user: AuthUser }> {
+export function getMe(token: string): Promise<{ user: AuthUser; role: AuthRole }> {
   return request("GET", "/auth/me", undefined, token);
 }
 


### PR DESCRIPTION
New one-way communication channel. Board members (via new CIVIC_BOARD_EMAILS env var) and admins can post + edit announcements. Instant-publish with transparent edits (edit_count + civic.process.updated). /auth/me + /auth/verify now return role; UI drops the hardcoded ADMIN_EMAIL in favor of role-driven gating throughout Nav. Feed renders announcements as 'Board announcement: …' or 'Announcement: …'. Public page at /announcement/:id with editable textarea-based form at /announcement/new and /announcement/:id/edit. Skips Civic Process Spec Phases 1-5 (Framing/Activation/Participation/Aggregation/Outcome) for this informational process kind — documented deviation, see HANDOFF.md.