### PR TITLE
Slice 4.1 — admin-editable announcement authors with flexible labels

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,11 +43,20 @@ CIVIC_ALLOWED_ORIGINS=
 # proposal review, brief review/approval, and delivery settings.
 CIVIC_ADMIN_EMAILS=
 
-# Comma-separated list of Board member emails. Narrow role: users in this
-# list can post and edit /announcement/* entries but cannot access any
-# /admin/* route. If a user's email is in both CIVIC_ADMIN_EMAILS and
-# CIVIC_BOARD_EMAILS, admin wins (full privileges). Case-insensitive.
-# If unset, nobody has the board role — only admins can post announcements.
+# Fallback list of announcement authors. Slice 4.1 introduces an
+# admin-managed author list stored in the hub_settings table (editable
+# from Admin → Civic Briefs → Announcement authors, with per-entry labels
+# like "Board member", "Planning Committee", etc.). That DB list wins
+# whenever it exists.
+#
+# This env var is only consulted when no DB row exists yet — in which
+# case each email here is authorized with the default label
+# "Board member". Useful as a safety-net bootstrap on fresh deploys.
+# Once an admin has saved the author list in the UI, this env var is
+# effectively ignored.
+#
+# Admins never need to appear here; CIVIC_ADMIN_EMAILS already grants
+# announcement-posting privileges (stamped as "Admin"). Case-insensitive.
 CIVIC_BOARD_EMAILS=
 
 # Node environment. Set to "production" on Vercel Production.

--- a/src/controllers/adminSettingsController.ts
+++ b/src/controllers/adminSettingsController.ts
@@ -1,22 +1,32 @@
 // Admin settings controller — read/write admin-configurable hub settings.
 //
-// Slice 3 exposes only brief recipient emails. More settings can be added
-// by extending the SettingsResponse shape and the PATCH body handler.
+// Exposes:
+//   - brief_recipient_emails  (Slice 3 addendum)
+//   - announcement_authors    (Slice 4.1: {email, label} list of non-admin
+//                              users authorized to post announcements)
+//
+// More settings can be added by extending SettingsResponse + the PATCH
+// body handler.
 
 import { Request, Response } from "express";
 import {
+  type AnnouncementAuthor,
+  getAnnouncementAuthors,
   getBriefRecipients,
+  setAnnouncementAuthors,
   setBriefRecipients,
 } from "../services/hubSettings.js";
 import { getAuthUser } from "../middleware/auth.js";
 
 interface SettingsResponse {
   brief_recipient_emails: string[];
+  announcement_authors: AnnouncementAuthor[];
 }
 
 async function loadSettings(): Promise<SettingsResponse> {
   return {
     brief_recipient_emails: await getBriefRecipients(),
+    announcement_authors: await getAnnouncementAuthors(),
   };
 }
 
@@ -38,7 +48,10 @@ export async function handlePatchSettings(
 ): Promise<void> {
   try {
     const actor = getAuthUser(res).id;
-    const body = (req.body ?? {}) as { brief_recipient_emails?: unknown };
+    const body = (req.body ?? {}) as {
+      brief_recipient_emails?: unknown;
+      announcement_authors?: unknown;
+    };
 
     if (body.brief_recipient_emails !== undefined) {
       if (!Array.isArray(body.brief_recipient_emails)) {
@@ -51,6 +64,25 @@ export async function handlePatchSettings(
         (e): e is string => typeof e === "string",
       );
       await setBriefRecipients(input, actor);
+    }
+
+    if (body.announcement_authors !== undefined) {
+      if (!Array.isArray(body.announcement_authors)) {
+        res.status(400).json({
+          error:
+            "announcement_authors must be an array of { email, label } objects.",
+        });
+        return;
+      }
+      const input: AnnouncementAuthor[] = [];
+      for (const entry of body.announcement_authors) {
+        if (!entry || typeof entry !== "object") continue;
+        const e = entry as { email?: unknown; label?: unknown };
+        if (typeof e.email === "string" && typeof e.label === "string") {
+          input.push({ email: e.email, label: e.label });
+        }
+      }
+      await setAnnouncementAuthors(input, actor);
     }
 
     res.json(await loadSettings());

--- a/src/controllers/announcementController.ts
+++ b/src/controllers/announcementController.ts
@@ -63,7 +63,15 @@ export async function handleCreateAnnouncement(
 ): Promise<void> {
   try {
     const user = getAuthUser(res);
-    const role = res.locals.effectiveRole as AnnouncementAuthorRole;
+    // The middleware resolved the user's display label — "Admin" for
+    // admins, or the admin-configured label (e.g. "Board member",
+    // "Planning Committee") for authors in the hub_settings list.
+    const authorLabel = res.locals.authorLabel as AnnouncementAuthorRole | undefined;
+    if (!authorLabel) {
+      throw new Error(
+        "authorLabel missing on res.locals — requireAnnouncementPoster must run before this handler.",
+      );
+    }
     const body = (req.body ?? {}) as { title?: unknown; body?: unknown };
 
     if (typeof body.title !== "string" || typeof body.body !== "string") {
@@ -85,7 +93,7 @@ export async function handleCreateAnnouncement(
         title: body.title,
         body: body.body,
         author_id: user.id,
-        author_role: role,
+        author_role: authorLabel,
         links: links ?? [],
       },
     });
@@ -132,7 +140,9 @@ export async function handleUpdateAnnouncement(
       return;
     }
     const user = getAuthUser(res);
-    const role = res.locals.effectiveRole as AnnouncementAuthorRole;
+    // effectiveRole is the permission role ("admin" | "author"), distinct
+    // from authorLabel which is the free-form display string.
+    const role = res.locals.effectiveRole as "admin" | "author";
 
     const body = (req.body ?? {}) as {
       title?: unknown;

--- a/src/controllers/authController.ts
+++ b/src/controllers/authController.ts
@@ -15,7 +15,7 @@ import {
   getUserFromToken,
   logout,
 } from "../modules/civic.auth/index.js";
-import { roleForEmail } from "../middleware/auth.js";
+import { resolveAuthorship } from "../middleware/auth.js";
 
 /**
  * POST /auth/request-code
@@ -58,9 +58,14 @@ export async function handleVerify(
 
   try {
     const result = await verifyCode(email, code);
-    // Include role alongside the token + user so the UI gets the admin /
-    // board bit without a follow-up /auth/me roundtrip on login.
-    res.json({ ...result, role: roleForEmail(result.user?.email) });
+    // Include role + author_label alongside the token + user so the UI
+    // gets the posting-privilege bit without a follow-up /auth/me call.
+    const authorship = await resolveAuthorship(result.user?.email);
+    res.json({
+      ...result,
+      role: authorship?.role ?? null,
+      author_label: authorship?.label ?? null,
+    });
   } catch (err) {
     const message = err instanceof Error ? err.message : "Unknown error";
     res.status(400).json({ error: message });
@@ -116,9 +121,15 @@ export async function handleGetMe(
     return;
   }
 
-  // Include the derived role so the UI can gate admin-only / Board-or-admin
-  // controls without hardcoding emails. null for residents.
-  res.json({ user, role: roleForEmail(user.email) });
+  // Include the derived role + author label so the UI can gate the admin
+  // link, the Post Announcement link, and the author-label display
+  // without hardcoding anything. null for residents.
+  const authorship = await resolveAuthorship(user.email);
+  res.json({
+    user,
+    role: authorship?.role ?? null,
+    author_label: authorship?.label ?? null,
+  });
 }
 
 /**

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -11,6 +11,7 @@
 
 import { NextFunction, Request, Response } from "express";
 import { getUserFromToken, type User } from "../modules/civic.auth/index.js";
+import { lookupAuthorLabel } from "../services/hubSettings.js";
 
 function extractToken(req: Request): string | null {
   const auth = req.headers.authorization;
@@ -38,16 +39,36 @@ function boardEmails(): Set<string> {
 }
 
 /**
- * Derive the effective role for a user based on their email. Admins win
- * if their email is in both lists (so an admin who's also listed as a
- * Board member gets full admin privileges, not the narrower Board role).
- * Returns null if the user has no elevated role.
+ * Quick sync admin check. Use when the DB-backed author list is not needed
+ * (e.g. gating /admin/*). For announcement posting where the author label
+ * matters, use `resolveAuthorship()` below.
  */
-export function roleForEmail(email: string | undefined | null): "admin" | "board" | null {
+export function isAdminEmail(email: string | undefined | null): boolean {
+  if (!email) return false;
+  return adminEmails().has(email.toLowerCase());
+}
+
+/**
+ * Resolve a user's effective role for announcement posting.
+ *
+ * Returns:
+ *   - { role: "admin", label: "Admin" } when the user is in
+ *     CIVIC_ADMIN_EMAILS. Admins always post as "Admin" regardless of
+ *     whether their email also appears in the author list.
+ *   - { role: "author", label: <configured label> } when the user's email
+ *     is in the admin-managed author list (hub_settings), falling back to
+ *     CIVIC_BOARD_EMAILS with a default label of "Board member".
+ *   - null when the user has no posting privilege.
+ *
+ * Async because the author list lives in hub_settings (Postgres).
+ */
+export async function resolveAuthorship(
+  email: string | undefined | null,
+): Promise<{ role: "admin" | "author"; label: string } | null> {
   if (!email) return null;
-  const lower = email.toLowerCase();
-  if (adminEmails().has(lower)) return "admin";
-  if (boardEmails().has(lower)) return "board";
+  if (isAdminEmail(email)) return { role: "admin", label: "Admin" };
+  const label = await lookupAuthorLabel(email);
+  if (label) return { role: "author", label };
   return null;
 }
 
@@ -134,18 +155,20 @@ export async function requireAdmin(
 }
 
 /**
- * Require an authenticated user whose email is in either
- * CIVIC_BOARD_EMAILS or CIVIC_ADMIN_EMAILS. Used for announcement
- * operations (post / edit).
+ * Require an authenticated user authorized to post announcements —
+ * either an admin, or a user in the admin-managed author list (with
+ * CIVIC_BOARD_EMAILS as an env-var fallback for the author list).
  *
- * Sets `res.locals.effectiveRole` to `"admin"` or `"board"` so handlers
- * can stamp the author role on new announcements without recomputing.
+ * Sets two values on res.locals for the handler to use:
+ *   - `effectiveRole`: "admin" | "author"
+ *   - `authorLabel`: the display label to stamp on new announcements
+ *     ("Admin" for admins; the configured label otherwise)
  *
- * This is intentionally separate from requireAdmin: Board members get
- * this one capability (announcements) and nothing else. /admin/* routes
- * keep using requireAdmin (strict) so Board members can't reach them.
+ * This is intentionally separate from requireAdmin. A user whose email
+ * is on the author list can post / edit announcements but cannot reach
+ * any /admin/* route.
  */
-export async function requireBoardOrAdmin(
+export async function requireAnnouncementPoster(
   req: Request,
   res: Response,
   next: NextFunction,
@@ -154,16 +177,26 @@ export async function requireBoardOrAdmin(
     const user = res.locals.authUser as User | undefined;
     if (!user) return;
 
-    const role = roleForEmail(user.email);
-    if (role === null) {
-      res.status(403).json({ error: "Board or admin access required" });
+    const authorship = await resolveAuthorship(user.email);
+    if (!authorship) {
+      res.status(403).json({
+        error:
+          "You are not authorized to post announcements. Ask an admin to add your email.",
+      });
       return;
     }
 
-    res.locals.effectiveRole = role;
+    res.locals.effectiveRole = authorship.role;
+    res.locals.authorLabel = authorship.label;
     next();
   });
 }
+
+// Backward-compat alias. Old callers imported `requireBoardOrAdmin`; the
+// new name is `requireAnnouncementPoster` which reflects the DB-backed,
+// flexible-label semantics. Leave this re-export in place so external
+// deploys that still reference the old name continue to work.
+export const requireBoardOrAdmin = requireAnnouncementPoster;
 
 /**
  * Helper: pull the authenticated user from res.locals, or throw 500.

--- a/src/modules/civic.announcement/lifecycle.ts
+++ b/src/modules/civic.announcement/lifecycle.ts
@@ -8,14 +8,20 @@
 //   - The original author can always edit their own announcement.
 //   - A user with admin role can edit any announcement (e.g. to correct
 //     a factual error or enforce policy).
-//   - A Board member cannot edit another Board member's announcement.
+//   - A non-admin author cannot edit another author's announcement.
 
-import type { AnnouncementProcessState, AnnouncementAuthorRole } from "./models.js";
+import type { AnnouncementProcessState } from "./models.js";
+
+/**
+ * Permission role distinct from the display label (author_role). Used
+ * only for authorization decisions.
+ */
+export type AnnouncementEditorRole = "admin" | "author";
 
 export function canEdit(
   state: AnnouncementProcessState,
   editorId: string,
-  editorRole: AnnouncementAuthorRole,
+  editorRole: AnnouncementEditorRole,
 ): boolean {
   if (editorRole === "admin") return true;
   return state.author_id === editorId;

--- a/src/modules/civic.announcement/models.ts
+++ b/src/modules/civic.announcement/models.ts
@@ -10,7 +10,18 @@
 // event emit function via AnnouncementProcessContext; the module never
 // imports the hub's event system directly.
 
-export type AnnouncementAuthorRole = "board" | "admin";
+/**
+ * Free-form display label for the announcement author. For admins this is
+ * always "Admin". For non-admin authors, the label comes from the
+ * admin-configured announcement_authors list (hub_settings) and can be
+ * any text — "Board member", "Planning Committee", "Guest speaker", etc.
+ * Rendered verbatim on the feed post and the public announcement page.
+ *
+ * Older announcements may still carry "board" as the value (from the
+ * Slice 4 union type); the UI treats both "board" and the literal label
+ * "Board member" the same way.
+ */
+export type AnnouncementAuthorRole = string;
 
 export interface AnnouncementLink {
   label: string;

--- a/src/modules/civic.announcement/service.ts
+++ b/src/modules/civic.announcement/service.ts
@@ -64,7 +64,7 @@ export async function emitPublicationEvents(
  */
 export async function updateAnnouncement(
   state: AnnouncementProcessState,
-  editor: { id: string; role: "board" | "admin" },
+  editor: { id: string; role: "admin" | "author" },
   patch: AnnouncementContentPatch,
   ctx: AnnouncementProcessContext,
 ): Promise<AnnouncementActionOutcome> {

--- a/src/services/hubSettings.ts
+++ b/src/services/hubSettings.ts
@@ -10,9 +10,25 @@ import { getDb } from "../db/client.js";
 
 export const SETTING_KEYS = {
   BRIEF_RECIPIENT_EMAILS: "brief_recipient_emails",
+  ANNOUNCEMENT_AUTHORS: "announcement_authors",
 } as const;
 
 export type SettingKey = (typeof SETTING_KEYS)[keyof typeof SETTING_KEYS];
+
+/**
+ * A non-admin user the admin has authorized to post Civic Hub
+ * announcements. `label` is rendered verbatim on the feed and the public
+ * announcement page ("{label} announcement: …", eyebrow "{LABEL}
+ * ANNOUNCEMENT"). Free-form so a hub can use "Board member", "Planning
+ * Committee", "Guest speaker", etc.
+ *
+ * Admins always post and are displayed as "Admin" regardless of whether
+ * they appear in this list.
+ */
+export interface AnnouncementAuthor {
+  email: string;
+  label: string;
+}
 
 interface SettingRow {
   key: string;
@@ -95,4 +111,81 @@ export async function setBriefRecipients(
     updatedBy,
   );
   return cleaned;
+}
+
+/**
+ * Read the admin-configured author list. Falls back to the
+ * CIVIC_BOARD_EMAILS env var (each entry labeled "Board member") when no
+ * DB row exists, so deploys before an admin has visited the settings
+ * panel keep working with their prior env-var configuration.
+ */
+export async function getAnnouncementAuthors(): Promise<AnnouncementAuthor[]> {
+  const stored = await getSetting(SETTING_KEYS.ANNOUNCEMENT_AUTHORS);
+  if (stored) {
+    try {
+      const parsed = JSON.parse(stored) as unknown;
+      if (Array.isArray(parsed)) {
+        return normalizeAuthors(parsed);
+      }
+    } catch {
+      // Fall through to env var — corrupt row shouldn't lock out Board
+      // members who worked yesterday.
+    }
+  }
+  // Env var fallback: CIVIC_BOARD_EMAILS → all entries labeled "Board member"
+  const envRaw = process.env.CIVIC_BOARD_EMAILS ?? "";
+  const envList = envRaw
+    .split(",")
+    .map((e) => e.trim())
+    .filter((e) => e.length > 0)
+    .map((email) => ({ email, label: "Board member" }));
+  return normalizeAuthors(envList);
+}
+
+export async function setAnnouncementAuthors(
+  authors: AnnouncementAuthor[],
+  updatedBy: string | null,
+): Promise<AnnouncementAuthor[]> {
+  const cleaned = normalizeAuthors(authors);
+  await setSetting(
+    SETTING_KEYS.ANNOUNCEMENT_AUTHORS,
+    JSON.stringify(cleaned),
+    updatedBy,
+  );
+  return cleaned;
+}
+
+/** Trim, dedup by lowercase email, drop empty. Preserve caller order. */
+function normalizeAuthors(raw: unknown[]): AnnouncementAuthor[] {
+  const seen = new Set<string>();
+  const out: AnnouncementAuthor[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== "object") continue;
+    const e = entry as { email?: unknown; label?: unknown };
+    const email = typeof e.email === "string" ? e.email.trim() : "";
+    const label = typeof e.label === "string" ? e.label.trim() : "";
+    if (!email || !label) continue;
+    const lower = email.toLowerCase();
+    if (seen.has(lower)) continue;
+    seen.add(lower);
+    out.push({ email, label });
+  }
+  return out;
+}
+
+/**
+ * Look up an email in the announcement author list. Returns the label to
+ * stamp on new announcements and render on their public page, or null if
+ * the email isn't authorized.
+ */
+export async function lookupAuthorLabel(
+  email: string | undefined | null,
+): Promise<string | null> {
+  if (!email) return null;
+  const lower = email.toLowerCase();
+  const authors = await getAnnouncementAuthors();
+  for (const a of authors) {
+    if (a.email.toLowerCase() === lower) return a.label;
+  }
+  return null;
 }

--- a/ui/src/components/AuthModal.tsx
+++ b/ui/src/components/AuthModal.tsx
@@ -78,7 +78,7 @@ export default function AuthModal({ onComplete, onDismiss }: Props) {
     setLoading(true);
     try {
       const result = await verifyCode(email.trim(), code.trim());
-      login(result.token, result.user, result.role);
+      login(result.token, result.user, result.role, result.author_label);
 
       if (result.user.is_resident) {
         // Already a resident (returning user) — done

--- a/ui/src/components/FeedPost.tsx
+++ b/ui/src/components/FeedPost.tsx
@@ -61,23 +61,32 @@ export function eventToPost(
         announcement?: {
           id?: string;
           title?: string;
-          author_role?: "board" | "admin";
+          author_role?: string;
         };
       };
 
       const cachedType = getProcessType(event.process_id);
 
-      // Announcement result_published
+      // Announcement result_published — render with the free-form author
+      // label. Admins show as "Announcement: …"; everyone else uses their
+      // configured label ("Board member announcement: …",
+      // "Planning Committee announcement: …", etc.). Legacy "board" from
+      // Slice 4 normalizes to "Board member" for grammar.
       if (data.announcement || cachedType === "civic.announcement") {
         const title =
           data.announcement?.title ??
           getProcessTitle(event.process_id) ??
           "Announcement";
-        const role = data.announcement?.author_role;
-        const label = role === "admin" ? "Announcement" : "Board announcement";
+        const rawLabel = data.announcement?.author_role;
+        const label =
+          rawLabel === "board" ? "Board member" : rawLabel ?? "Admin";
+        const postTitle =
+          label === "Admin"
+            ? `Announcement: ${title}`
+            : `${label} announcement: ${title}`;
         return {
           id: event.id,
-          title: `${label}: ${title}`,
+          title: postTitle,
           summary: summaryFromDescription(
             getProcessDescription(event.process_id),
           ),

--- a/ui/src/context/AuthContext.tsx
+++ b/ui/src/context/AuthContext.tsx
@@ -19,17 +19,30 @@ interface AuthState {
   /** Whether the user is fully ready to participate (authenticated + resident) */
   canParticipate: boolean;
   /**
-   * Elevated role derived server-side from CIVIC_ADMIN_EMAILS /
-   * CIVIC_BOARD_EMAILS. null for residents without special privileges.
-   * Admins can do everything Board members can plus admin-panel access.
+   * Permission role derived server-side. "admin" = full admin panel.
+   * "author" = authorized to post announcements. null = resident.
    */
   role: AuthRole;
+  /**
+   * Free-form display label for the author's announcements — "Admin",
+   * "Board member", "Planning Committee", etc. Comes from the admin's
+   * configured author list for non-admins, always "Admin" for admins,
+   * null for residents. The UI uses this only for display hints; the
+   * server stamps the authoritative label on each announcement at post
+   * time.
+   */
+  authorLabel: string | null;
   /** Convenience: true when role is "admin". */
   isAdmin: boolean;
-  /** Convenience: true when role is "admin" OR "board". */
+  /** Convenience: true when role is "admin" OR "author". */
   canPostAnnouncements: boolean;
   /** Login with a token and user from the verify step */
-  login: (token: string, user: AuthUser, role?: AuthRole) => void;
+  login: (
+    token: string,
+    user: AuthUser,
+    role?: AuthRole,
+    authorLabel?: string | null,
+  ) => void;
   /** Update user after residency affirmation */
   updateUser: (user: AuthUser) => void;
   /** Logout and clear session */
@@ -42,6 +55,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<AuthUser | null>(null);
   const [token, setToken] = useState<string | null>(null);
   const [role, setRole] = useState<AuthRole>(null);
+  const [authorLabel, setAuthorLabel] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
 
   // Try to restore session from localStorage on mount
@@ -49,9 +63,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const stored = getStoredToken();
     if (stored) {
       getMe(stored)
-        .then(({ user: u, role: r }) => {
+        .then(({ user: u, role: r, author_label }) => {
           setUser(u);
           setRole(r ?? null);
+          setAuthorLabel(author_label ?? null);
           setToken(stored);
         })
         .catch(() => {
@@ -65,11 +80,17 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const login = useCallback(
-    (newToken: string, newUser: AuthUser, newRole: AuthRole = null) => {
+    (
+      newToken: string,
+      newUser: AuthUser,
+      newRole: AuthRole = null,
+      newAuthorLabel: string | null = null,
+    ) => {
       storeToken(newToken);
       setToken(newToken);
       setUser(newUser);
       setRole(newRole);
+      setAuthorLabel(newAuthorLabel);
     },
     [],
   );
@@ -86,12 +107,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setToken(null);
     setUser(null);
     setRole(null);
+    setAuthorLabel(null);
   }, [token]);
 
   const actorId = user?.id ?? null;
   const canParticipate = !!user && user.email_verified && user.is_resident;
   const isAdmin = role === "admin";
-  const canPostAnnouncements = role === "admin" || role === "board";
+  const canPostAnnouncements = role === "admin" || role === "author";
 
   return (
     <AuthContext.Provider
@@ -102,6 +124,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         actorId,
         canParticipate,
         role,
+        authorLabel,
         isAdmin,
         canPostAnnouncements,
         login,

--- a/ui/src/pages/AdminBriefs.css
+++ b/ui/src/pages/AdminBriefs.css
@@ -44,6 +44,14 @@
   color: var(--color-text-muted);
 }
 
+.announcement-author-row {
+  display: grid;
+  grid-template-columns: 2fr 1.3fr auto;
+  gap: var(--space-sm);
+  margin-bottom: var(--space-sm);
+  align-items: center;
+}
+
 .admin-brief-filters {
   display: flex;
   gap: var(--space-sm);

--- a/ui/src/pages/AdminBriefs.tsx
+++ b/ui/src/pages/AdminBriefs.tsx
@@ -7,6 +7,7 @@ import {
   adminApproveBrief,
   adminGetSettings,
   adminPatchSettings,
+  type AnnouncementAuthor,
   type BriefDetail,
   type BriefPublicationStatus,
   type BriefSummary,
@@ -40,22 +41,71 @@ export default function AdminBriefs() {
   const [approving, setApproving] = useState(false);
   const [confirmingApprove, setConfirmingApprove] = useState(false);
 
-  // Settings (recipient email list)
+  // Settings: recipient email list (brief delivery)
   const [recipientsText, setRecipientsText] = useState("");
-  const [recipientsLoaded, setRecipientsLoaded] = useState(false);
+  const [settingsLoaded, setSettingsLoaded] = useState(false);
   const [savingRecipients, setSavingRecipients] = useState(false);
   const [recipientsMessage, setRecipientsMessage] = useState<string | null>(null);
+
+  // Settings: announcement authors (who can post announcements)
+  const [authors, setAuthors] = useState<AnnouncementAuthor[]>([]);
+  const [savingAuthors, setSavingAuthors] = useState(false);
+  const [authorsMessage, setAuthorsMessage] = useState<string | null>(null);
 
   useEffect(() => {
     adminGetSettings()
       .then((s) => {
         setRecipientsText(s.brief_recipient_emails.join(", "));
-        setRecipientsLoaded(true);
+        setAuthors(s.announcement_authors);
+        setSettingsLoaded(true);
       })
       .catch((err: Error) => {
         setError(`Could not load settings: ${err.message}`);
       });
   }, []);
+
+  function updateAuthor(i: number, patch: Partial<AnnouncementAuthor>) {
+    setAuthors((cur) => cur.map((a, idx) => (idx === i ? { ...a, ...patch } : a)));
+  }
+
+  function addAuthor() {
+    setAuthors((cur) => [...cur, { email: "", label: "Board member" }]);
+  }
+
+  function removeAuthor(i: number) {
+    setAuthors((cur) => cur.filter((_, idx) => idx !== i));
+  }
+
+  async function saveAuthors() {
+    setSavingAuthors(true);
+    setAuthorsMessage(null);
+    try {
+      // Drop fully-empty rows, but surface any half-filled rows as errors.
+      const cleaned: AnnouncementAuthor[] = [];
+      for (const a of authors) {
+        const email = a.email.trim();
+        const label = a.label.trim();
+        if (!email && !label) continue;
+        if (!email || !label) {
+          throw new Error("Each author needs both an email and a label.");
+        }
+        cleaned.push({ email, label });
+      }
+      const saved = await adminPatchSettings({ announcement_authors: cleaned });
+      setAuthors(saved.announcement_authors);
+      setAuthorsMessage(
+        saved.announcement_authors.length === 0
+          ? "Cleared — only admins can post announcements."
+          : `Saved. ${saved.announcement_authors.length} non-admin author(s) can now post.`,
+      );
+    } catch (err) {
+      setAuthorsMessage(
+        err instanceof Error ? err.message : "Failed to save authors",
+      );
+    } finally {
+      setSavingAuthors(false);
+    }
+  }
 
   async function saveRecipients() {
     setSavingRecipients(true);
@@ -331,7 +381,7 @@ export default function AdminBriefs() {
             rows={2}
             value={recipientsText}
             onChange={(e) => setRecipientsText(e.target.value)}
-            disabled={!recipientsLoaded || savingRecipients}
+            disabled={!settingsLoaded || savingRecipients}
             placeholder="board@floyd.gov, clerk@floyd.gov"
           />
           <div className="admin-settings-actions">
@@ -339,12 +389,82 @@ export default function AdminBriefs() {
               type="button"
               className="admin-convert-button"
               onClick={saveRecipients}
-              disabled={!recipientsLoaded || savingRecipients}
+              disabled={!settingsLoaded || savingRecipients}
             >
               {savingRecipients ? "Saving…" : "Save recipients"}
             </button>
             {recipientsMessage && (
               <span className="admin-settings-message">{recipientsMessage}</span>
+            )}
+          </div>
+        </section>
+
+        <section className="admin-settings-panel">
+          <h3>Announcement authors</h3>
+          <p className="form-hint">
+            Non-admin users who can post announcements. The label shows on
+            the public feed and announcement page — e.g. "Board member",
+            "Planning Committee", "Guest speaker". Admins can always post
+            (as "Admin") and don't need to be listed here.
+          </p>
+
+          {authors.length === 0 && (
+            <p className="empty-state-inline" style={{ margin: "var(--space-sm) 0" }}>
+              No non-admin authors configured. Only admins can post announcements.
+            </p>
+          )}
+
+          {authors.map((author, i) => (
+            <div key={i} className="announcement-author-row">
+              <input
+                className="form-input"
+                type="email"
+                value={author.email}
+                onChange={(e) => updateAuthor(i, { email: e.target.value })}
+                placeholder="author@example.com"
+                disabled={!settingsLoaded || savingAuthors}
+              />
+              <input
+                className="form-input"
+                type="text"
+                value={author.label}
+                onChange={(e) => updateAuthor(i, { label: e.target.value })}
+                placeholder="Board member"
+                disabled={!settingsLoaded || savingAuthors}
+                maxLength={50}
+              />
+              <button
+                type="button"
+                className="admin-remove-section"
+                onClick={() => removeAuthor(i)}
+                disabled={savingAuthors}
+                aria-label={`Remove author ${i + 1}`}
+              >
+                ×
+              </button>
+            </div>
+          ))}
+
+          <button
+            type="button"
+            className="admin-add-section"
+            onClick={addAuthor}
+            disabled={!settingsLoaded || savingAuthors}
+          >
+            + Add author
+          </button>
+
+          <div className="admin-settings-actions" style={{ marginTop: "var(--space-md)" }}>
+            <button
+              type="button"
+              className="admin-convert-button"
+              onClick={saveAuthors}
+              disabled={!settingsLoaded || savingAuthors}
+            >
+              {savingAuthors ? "Saving…" : "Save authors"}
+            </button>
+            {authorsMessage && (
+              <span className="admin-settings-message">{authorsMessage}</span>
             )}
           </div>
         </section>

--- a/ui/src/pages/Announcement.tsx
+++ b/ui/src/pages/Announcement.tsx
@@ -55,8 +55,11 @@ export default function AnnouncementPage() {
     );
   }
 
+  // Legacy Slice-4 announcements may have author_role === "board" —
+  // normalize for display. Everything else renders verbatim.
   const roleLabel =
-    announcement.author_role === "board" ? "Board member" : "Admin";
+    announcement.author_role === "board" ? "Board member" : announcement.author_role;
+  const isAdminLabel = roleLabel === "Admin";
   const canEdit =
     isAdmin || (!!user?.id && user.id === announcement.author_id);
   const wasEdited = announcement.edit_count > 0;
@@ -68,9 +71,7 @@ export default function AnnouncementPage() {
       </Link>
       <header className="announcement-header">
         <p className="announcement-eyebrow">
-          {announcement.author_role === "board"
-            ? "Board announcement"
-            : "Announcement"}
+          {isAdminLabel ? "Announcement" : `${roleLabel} announcement`}
         </p>
         <h1>{announcement.title}</h1>
         <p className="announcement-meta">

--- a/ui/src/services/api.ts
+++ b/ui/src/services/api.ts
@@ -517,7 +517,15 @@ export function getPublicBrief(id: string): Promise<PublicBrief> {
 
 // --- Announcements ---
 
-export type AnnouncementAuthorRole = "board" | "admin";
+/**
+ * Free-form display label for the announcement author ("Admin", "Board
+ * member", "Planning Committee", etc.). Server-side admins always get
+ * "Admin"; non-admin authors get the label configured in the admin's
+ * announcement_authors list. Rendered verbatim on the feed and the
+ * public announcement page. Older Slice 4 announcements may carry
+ * "board" — renders fine either way.
+ */
+export type AnnouncementAuthorRole = string;
 
 export interface AnnouncementLink {
   label: string;
@@ -585,8 +593,14 @@ export function listAnnouncements(limit?: number): Promise<AnnouncementSummary[]
 
 // --- Admin: hub settings ---
 
+export interface AnnouncementAuthor {
+  email: string;
+  label: string;
+}
+
 export interface AdminSettings {
   brief_recipient_emails: string[];
+  announcement_authors: AnnouncementAuthor[];
 }
 
 export function adminGetSettings(): Promise<AdminSettings> {

--- a/ui/src/services/auth.ts
+++ b/ui/src/services/auth.ts
@@ -36,11 +36,12 @@ export interface AuthUser {
 }
 
 /**
- * Elevated role for the authenticated user, derived server-side from
- * CIVIC_ADMIN_EMAILS / CIVIC_BOARD_EMAILS env vars. null for residents
- * with no special privileges.
+ * Permission role derived server-side. "admin" = full admin panel
+ * access. "author" = user authorized to post announcements (via the
+ * admin-managed list in hub_settings, with CIVIC_BOARD_EMAILS as a
+ * fallback). null = regular resident with no special privileges.
  */
-export type AuthRole = "admin" | "board" | null;
+export type AuthRole = "admin" | "author" | null;
 
 // --- Token storage ---
 
@@ -67,7 +68,12 @@ export function requestCode(email: string): Promise<{ message: string }> {
 export function verifyCode(
   email: string,
   code: string
-): Promise<{ token: string; user: AuthUser; role: AuthRole }> {
+): Promise<{
+  token: string;
+  user: AuthUser;
+  role: AuthRole;
+  author_label: string | null;
+}> {
   return request("POST", "/auth/verify", { email, code });
 }
 
@@ -75,7 +81,9 @@ export function affirmResidency(token: string): Promise<{ user: AuthUser }> {
   return request("POST", "/auth/residency", undefined, token);
 }
 
-export function getMe(token: string): Promise<{ user: AuthUser; role: AuthRole }> {
+export function getMe(
+  token: string,
+): Promise<{ user: AuthUser; role: AuthRole; author_label: string | null }> {
   return request("GET", "/auth/me", undefined, token);
 }
 


### PR DESCRIPTION
Replaces Slice 4's hardcoded board/admin role union with an admin-managed author list in hub_settings, where each entry has a free-form label ("Board member", "Planning Committee", "Guest speaker", etc.). Admin stays strict; non-admin authors post with their configured label. CIVIC_BOARD_EMAILS env var continues to work as a fallback. Fully backward-compatible with existing Slice 4 announcements. See HANDOFF.md.