### PR TITLE
Slice 18: env-driven hub branding for multi-deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,12 @@ dist/
 *.js.map
 *.d.ts.map
 .env
+# Slice 18 — the UI's env file carries public branding defaults
+# (VITE_HUB_*) and ships in the bundle. Whitelist so production
+# builds get the Floyd defaults without an out-of-band setup step.
+# DO NOT put secrets here — Vite exposes VITE_-prefixed vars to
+# client code. Backend/server env vars belong in civic-hub/.env.
+!ui/.env
 
 # OS artifacts
 .DS_Store

--- a/ui/.env
+++ b/ui/.env
@@ -1,0 +1,43 @@
+# Vite UI build-time defaults — Slice 18.
+#
+# Committed to git. Holds the Floyd-production branding values used
+# by index.html's %VITE_VAR% substitution and (as fallback) by
+# src/config/hub.ts when no override is set.
+#
+# Per-deployment overrides go in Vercel project Settings →
+# Environment Variables (Production scope). Any value set there
+# takes precedence over what's in this file at `vite build` time.
+#
+# DO NOT put secrets in this file — it ships in the bundle. Vite's
+# convention: only VITE_-prefixed vars are exposed to client code.
+#
+# To add a new branding field:
+#   1. Add a VITE_HUB_<NAME>= line here with the Floyd default.
+#   2. Reference %VITE_HUB_<NAME>% in index.html (for OG / title)
+#      or import.meta.env.VITE_HUB_<NAME> from src/config/hub.ts.
+#   3. Document the new field in .env.example for operator setup.
+
+# Wordmark / display name. Top nav, footer, intro popup, settings,
+# search header. Not the geographic jurisdiction.
+VITE_HUB_NAME=Floyd Civic Hub
+
+# Geographic jurisdiction. Banner + residency-affirmation copy.
+VITE_HUB_JURISDICTION=Floyd County, Virginia
+
+# Banner type label. Small caps under the jurisdiction.
+VITE_HUB_LABEL=Civic Hub
+
+# One-sentence tagline rendered under the jurisdiction.
+VITE_HUB_TAGLINE=Stay informed on Floyd County government, raise the issues that matter, and see where our community stands.
+
+# Banner image path. Relative to deployment root.
+VITE_HUB_BANNER_URL=/floyd-banner.jpg
+
+# Banner alt text — also serves as og:image:alt.
+VITE_HUB_BANNER_ALT=Downtown Floyd, Virginia — the Floyd Civic Hub
+
+# Browser tab title and og:title.
+VITE_HUB_PAGE_TITLE=Floyd County, VA — Civic Hub
+
+# Meta description and og:description.
+VITE_HUB_DESCRIPTION=Vote on local issues and see where our community stands. Floyd County, Virginia Civic Hub.

--- a/ui/.env.example
+++ b/ui/.env.example
@@ -1,0 +1,38 @@
+# Vite UI build-time configuration.
+#
+# Each Vercel project deployed from this codebase can override these
+# defaults to render its own branding. The committed `.env` file in
+# this directory carries the Floyd Civic Hub production defaults;
+# anything set in Vercel's project Settings → Environment Variables
+# (Production scope) takes precedence at `vite build` time.
+#
+# Demo deployment example: a separate Vercel project pointing at the
+# same repo + main branch, with these env vars set under "Production"
+# scope to render demo branding:
+#
+#   VITE_HUB_NAME=Civic Social Demo Hub
+#   VITE_HUB_JURISDICTION=Demo County, Civic Social
+#   VITE_HUB_LABEL=Demo Hub
+#   VITE_HUB_TAGLINE=A live demonstration of the Civic Hub product…
+#   VITE_HUB_BANNER_URL=/demo-banner.jpg
+#   VITE_HUB_BANNER_ALT=Civic Social demo banner
+#   VITE_HUB_PAGE_TITLE=Civic Social — Demo Hub
+#   VITE_HUB_DESCRIPTION=Try the Civic Hub product…
+#
+# Any banner image referenced via VITE_HUB_BANNER_URL must be present
+# under civic-hub/ui/public/ at the same path (the deployment serves
+# everything in public/ at the root). Drop new images into public/
+# and reference them like `/your-banner.jpg`.
+#
+# IMPORTANT: only VITE_-prefixed vars are exposed to the client
+# bundle by Vite. Backend/server env vars (RESEND_API_KEY, SUPABASE_*,
+# CRON_SECRET, etc.) belong in civic-hub/.env, NOT here.
+
+VITE_HUB_NAME=Floyd Civic Hub
+VITE_HUB_JURISDICTION=Floyd County, Virginia
+VITE_HUB_LABEL=Civic Hub
+VITE_HUB_TAGLINE=Stay informed on Floyd County government, raise the issues that matter, and see where our community stands.
+VITE_HUB_BANNER_URL=/floyd-banner.jpg
+VITE_HUB_BANNER_ALT=Downtown Floyd, Virginia — the Floyd Civic Hub
+VITE_HUB_PAGE_TITLE=Floyd County, VA — Civic Hub
+VITE_HUB_DESCRIPTION=Vote on local issues and see where our community stands. Floyd County, Virginia Civic Hub.

--- a/ui/index.html
+++ b/ui/index.html
@@ -32,17 +32,24 @@
         min-height: 100dvh;
       }
     </style>
-    <title>Floyd County, VA — Civic Hub</title>
-    <meta name="description" content="Vote on local issues and see where our community stands. Floyd County, Virginia Civic Hub." />
-    <meta property="og:title" content="Floyd County, VA — Civic Hub" />
-    <meta property="og:description" content="Vote on local issues and see where our community stands." />
+    <!-- Slice 18 — title / OG metadata are env-driven via Vite's
+         %VITE_VAR% substitution so per-deployment Vercel projects
+         (Floyd production, civic.social demo, future per-county
+         hubs) render their own branding from the same `main` build.
+         Defaults below match Floyd; overrides go in each Vercel
+         project's Production-scoped env vars. -->
+    <title>%VITE_HUB_PAGE_TITLE%</title>
+    <meta name="description" content="%VITE_HUB_DESCRIPTION%" />
+    <meta property="og:title" content="%VITE_HUB_PAGE_TITLE%" />
+    <meta property="og:description" content="%VITE_HUB_DESCRIPTION%" />
     <meta property="og:type" content="website" />
-    <!-- Slice 15 — static OG image. The SPA can't inject per-vote OG
-         tags (crawlers don't run JS), so every shared link unfurls
-         with the Hub banner + generic title. Per-vote OG would need
-         a server-side bot-detection rewrite (Slice 15.1 candidate). -->
-    <meta property="og:image" content="/floyd-banner.jpg" />
-    <meta property="og:image:alt" content="Downtown Floyd, Virginia — the Floyd Civic Hub" />
+    <!-- Static OG image. The SPA can't inject per-vote OG tags
+         (crawlers don't run JS), so every shared link unfurls
+         with the Hub banner + generic title. Per-vote OG would
+         need a server-side bot-detection rewrite (Slice 15.1
+         candidate). -->
+    <meta property="og:image" content="%VITE_HUB_BANNER_URL%" />
+    <meta property="og:image:alt" content="%VITE_HUB_BANNER_ALT%" />
     <meta name="twitter:card" content="summary_large_image" />
   </head>
   <body>

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { BrowserRouter, Routes, Route, Navigate, useLocation, useParams, Link } from "react-router-dom";
 import { AuthProvider } from "./context/AuthContext";
+import hub from "./config/hub";
 import Nav from "./components/Nav";
 import HubBanner from "./components/HubBanner";
 import Home from "./pages/Home";
@@ -131,7 +132,7 @@ function SiteFooter() {
     <footer className="app-footer">
       <div className="app-footer-inner">
         <div className="app-footer-brand">
-          <strong>Floyd Civic Hub</strong>
+          <strong>{hub.name}</strong>
           <span className="app-footer-tagline">
             Operated by Adam Lake · Powered by{" "}
             <a

--- a/ui/src/components/AuthModal.tsx
+++ b/ui/src/components/AuthModal.tsx
@@ -9,6 +9,7 @@ import {
   type AuthUser,
 } from "../services/auth";
 import { CURRENT_LEGAL_VERSION } from "../config/legal";
+import hub from "../config/hub";
 
 /**
  * Slice 13.10: deferred login() until the residency + legal gate
@@ -314,7 +315,7 @@ export default function AuthModal({ onComplete, onDismiss }: Props) {
                 disabled={loading}
               />
               <span>
-                I confirm that I am a resident of Floyd County, Virginia, and
+                I confirm that I am a resident of {hub.jurisdiction}, and
                 I have read and agree to the{" "}
                 <a href="/terms" target="_blank" rel="noopener noreferrer">
                   Terms of Service

--- a/ui/src/components/IntroPopup.tsx
+++ b/ui/src/components/IntroPopup.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
+import hub from "../config/hub";
 import "./IntroPopup.css";
 
 const STORAGE_KEY = "seen_intro_popup";
@@ -82,7 +83,7 @@ export default function IntroPopup({ onDismiss }: Props) {
     >
       <div className="intro-popup-body">
         <h2 id="intro-popup-title" className="intro-popup-title">
-          Welcome to the Floyd Civic Hub.
+          Welcome to the {hub.name}.
         </h2>
 
         <p className="intro-popup-text">

--- a/ui/src/components/Nav.tsx
+++ b/ui/src/components/Nav.tsx
@@ -168,7 +168,7 @@ export default function Nav() {
             </button>
 
             <Link to="/" className="civic-nav-wordmark" aria-label={`${hub.jurisdiction} home`}>
-              Floyd Civic Hub
+              {hub.name}
             </Link>
 
             {TOP_LINKS.length > 0 && (

--- a/ui/src/components/ReAcceptModal.tsx
+++ b/ui/src/components/ReAcceptModal.tsx
@@ -14,6 +14,7 @@
 import { useState } from "react";
 import { useAuth } from "../context/AuthContext";
 import { acceptTos } from "../services/auth";
+import hub from "../config/hub";
 import {
   CURRENT_LEGAL_VERSION,
   CURRENT_LEGAL_LAST_UPDATED,
@@ -82,7 +83,7 @@ export default function ReAcceptModal() {
             : "We've updated our Terms"}
         </h2>
         <p id="re-accept-body" className="auth-description">
-          To keep using the Floyd Civic Hub, please review our Terms of
+          To keep using the {hub.name}, please review our Terms of
           Service, Privacy Policy, and Code of Conduct. These protect
           you and help us run the Hub fairly.
         </p>

--- a/ui/src/config/hub.ts
+++ b/ui/src/config/hub.ts
@@ -1,16 +1,62 @@
 /**
- * Static hub configuration.
- * In the future this will come from the backend discovery manifest
- * or a hub settings API. For now it's hardcoded.
+ * Hub branding config — read at build time from VITE_HUB_* env vars,
+ * with Floyd County defaults baked in. This lets a single codebase
+ * power multiple Vercel projects (Floyd production, civic.social
+ * demo, future per-county hubs) without per-deployment branches:
+ * the same `main` build serves everywhere; each Vercel project
+ * sets its own VITE_HUB_* values and gets its own branding.
+ *
+ * Add a new field by extending the `hub` object below and the
+ * VITE_HUB_* env-var read above it. Keep the Floyd default
+ * accurate so production deployments without overrides keep
+ * working.
+ *
+ * NOT an env-driven concern (these stay code-side):
+ *   - Theme colors / fonts (use a separate VITE_HUB_THEME flag and
+ *     CSS variable overrides if/when that's needed).
+ *   - Legal copy (lives in /content/legal/*.md; see LegalPage.tsx).
+ *   - Per-page UI copy that's intrinsically Floyd-civic-specific
+ *     (e.g. About-page content describing the hub's mission).
  */
 
 const hub = {
-  jurisdiction: "Floyd County, Virginia",
-  label: "Civic Hub",
-  tagline: "Stay informed on Floyd County government, raise the issues that matter, and see where our community stands.",
-  // Local banner image — downtown Floyd, VA (Routes 221 & 8 intersection)
-  // Replaces the external Unsplash URL to comply with no-external-network constraint
-  banner_url: "/floyd-banner.jpg",
+  /**
+   * Display name / wordmark — appears in the top-nav, footer,
+   * intro popup, settings, search header, etc. Not the geographic
+   * jurisdiction.
+   */
+  name: import.meta.env.VITE_HUB_NAME ?? "Floyd Civic Hub",
+  /**
+   * Geographic jurisdiction — appears on the banner / hub-info
+   * card and in residency-affirmation copy. The "place this hub
+   * serves." Stays accurate to the actual served community even
+   * when `name` is rebranded for demo / white-label use.
+   */
+  jurisdiction:
+    import.meta.env.VITE_HUB_JURISDICTION ?? "Floyd County, Virginia",
+  /**
+   * Type label — small caps under the jurisdiction on the banner.
+   */
+  label: import.meta.env.VITE_HUB_LABEL ?? "Civic Hub",
+  /**
+   * One-sentence tagline rendered under the jurisdiction.
+   */
+  tagline:
+    import.meta.env.VITE_HUB_TAGLINE ??
+    "Stay informed on Floyd County government, raise the issues that matter, and see where our community stands.",
+  /**
+   * Banner image path. Relative to the deployment root — drop new
+   * banner files into `civic-hub/ui/public/` and point this var at
+   * their path. Free-tier deploys get same domain/CDN, so /demo-
+   * banner.jpg works.
+   */
+  banner_url: import.meta.env.VITE_HUB_BANNER_URL ?? "/floyd-banner.jpg",
+  /**
+   * Alt text for the banner — also used in og:image:alt.
+   */
+  banner_alt:
+    import.meta.env.VITE_HUB_BANNER_ALT ??
+    "Downtown Floyd, Virginia — the Floyd Civic Hub",
 };
 
 export default hub;

--- a/ui/src/pages/Search.tsx
+++ b/ui/src/pages/Search.tsx
@@ -9,6 +9,7 @@ import {
 } from "../services/api";
 import SearchBar from "../components/SearchBar";
 import { relativeTime, absoluteTime } from "../components/FeedPost";
+import hub from "../config/hub";
 // FeedFilter.css carries the .feed-filter-pill--<kind> rules we
 // reuse for the post-type filter row on this page. Imported here
 // since Search doesn't render <FeedFilter> directly.
@@ -230,7 +231,7 @@ export default function SearchPage() {
 
       <header className="search-page-header">
         <h1>
-          {q ? <>Search results for <em>{q}</em></> : "Search Floyd Civic Hub"}
+          {q ? <>Search results for <em>{q}</em></> : `Search ${hub.name}`}
         </h1>
         <div className="search-page-input">
           <SearchBar inDrawer initialValue={q} />

--- a/ui/src/pages/Settings.tsx
+++ b/ui/src/pages/Settings.tsx
@@ -9,6 +9,7 @@ import { useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useAuth } from "../context/AuthContext";
 import { setDigestSubscription } from "../services/api";
+import hub from "../config/hub";
 import {
   deleteAccount as deleteAccountApi,
   getMe,
@@ -124,7 +125,7 @@ export default function Settings() {
       <div className="settings-body">
         <h1>Settings</h1>
         <p className="settings-subtitle">
-          Manage how you hear from {"Floyd Civic Hub"}.
+          Manage how you hear from {hub.name}.
         </p>
 
         {error && <p className="form-error">{error}</p>}


### PR DESCRIPTION
## Summary
- Refactor UI to read all hub-branding values from `VITE_HUB_*` build-time env vars, with Floyd defaults baked in.
- Unlocks running multiple Vercel projects from the same `main` branch — Floyd production stays unchanged; a future demo Vercel project (e.g. `demo-hub.civic.social`) gets its own name, banner, tagline, and metadata via Vercel env-var overrides.
- Visually a no-op for Floyd: two layers of defaults (committed `ui/.env` values + `??` fallbacks in code) ensure Floyd's strings render identically.

## Verified on preview
Pushed to `slice-18-env-driven-branding`, Vercel preview deployment eyeballed against `floyd.civic.social`:
- Top-nav wordmark, banner image + alt, hub-info name/label/tagline, footer brand, browser tab title, intro popup greeting all render identical Floyd values.

## Test plan
- [x] `npm run build` clean both roots
- [x] Default build (no overrides): every UI surface renders Floyd values
- [x] Override build: setting `VITE_HUB_NAME` etc. produces a different rendered title/og:image/etc.
- [x] Vercel preview deploy verified against floyd.civic.social
- [ ] Post-merge: floyd.civic.social rebuilds with no visible change

## Follow-ups (not in this PR)
- Create separate Supabase project for demo
- Create separate Vercel project pointing at `main` with demo env vars + demo Supabase
- Configure DNS for `demo-hub.civic.social`
- Drop a `/demo-banner.jpg` into `ui/public/` for demo branding

🤖 Generated with [Claude Code](https://claude.com/claude-code)