### PR TITLE
Slice 19a + 19b: governance terminology env vars + Athens seed fixture

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,6 +84,13 @@ CIVIC_ALLOW_SEED=true
 # in Production so real verification is enforced.
 CIVIC_DEMO_BYPASS_CODE=000000
 
+# Slice 19b — selects which seed fixture loads when CIVIC_ALLOW_SEED=true
+# and the processes table is empty. Default "floyd" (Green Box +
+# Flock Camera votes for Floyd County). Set to "athens" on the
+# civic.social demo deployment to load the same vote topics rebranded
+# for the fictional Town of Athens, Virginia.
+CIVIC_SEED_FIXTURE=floyd
+
 # --- SMTP (Civic Brief delivery) ---
 # When all five SMTP_* vars below are set, admin approval of a Civic Brief
 # delivers the formatted brief to BOARD_RECIPIENT_EMAIL via nodemailer.

--- a/src/debug/autoSeed.ts
+++ b/src/debug/autoSeed.ts
@@ -21,9 +21,40 @@ import {
   FLOYD_GREEN_BOX,
   type SeedScenario,
 } from "./seedData.js";
+import {
+  ATHENS_FLOCK_CAMERA,
+  ATHENS_GREEN_BOX,
+} from "./seedDataAthens.js";
 
 function allowSeed(): boolean {
   return process.env.CIVIC_ALLOW_SEED === "true";
+}
+
+/**
+ * Slice 19b — fixture selector. Each Vercel deployment can pick which
+ * jurisdiction's seed data to load via CIVIC_SEED_FIXTURE. Floyd is
+ * the default so production behavior is unchanged; the Athens fixture
+ * powers the public demo at demo-hub.civic.social.
+ *
+ * Add a new fixture by exporting scenarios from a new seed-data
+ * module and adding a case below — handlers should be cheap (just
+ * scenario references) so adding a fixture is a one-line change.
+ */
+function selectScenarios(): SeedScenario[] {
+  const fixture = process.env.CIVIC_SEED_FIXTURE?.trim().toLowerCase();
+  switch (fixture) {
+    case "athens":
+      return [ATHENS_GREEN_BOX, ATHENS_FLOCK_CAMERA];
+    case "floyd":
+    case undefined:
+    case "":
+      return [FLOYD_GREEN_BOX, FLOYD_FLOCK_CAMERA];
+    default:
+      console.warn(
+        `[auto-seed] Unknown CIVIC_SEED_FIXTURE="${fixture}" — falling back to floyd.`,
+      );
+      return [FLOYD_GREEN_BOX, FLOYD_FLOCK_CAMERA];
+  }
 }
 
 async function runScenario(scenario: SeedScenario): Promise<void> {
@@ -70,9 +101,12 @@ export async function seedOnStartup(): Promise<void> {
       return;
     }
 
-    console.log("[auto-seed] Seeding initial data...");
-    await runScenario(FLOYD_GREEN_BOX);
-    await runScenario(FLOYD_FLOCK_CAMERA);
+    const scenarios = selectScenarios();
+    const fixtureName = process.env.CIVIC_SEED_FIXTURE?.trim().toLowerCase() || "floyd";
+    console.log(`[auto-seed] Seeding initial data (fixture: ${fixtureName})...`);
+    for (const scenario of scenarios) {
+      await runScenario(scenario);
+    }
     console.log("[auto-seed] Done\n");
   })().catch((err) => {
     console.error("[auto-seed] failed:", err);

--- a/src/debug/seedDataAthens.ts
+++ b/src/debug/seedDataAthens.ts
@@ -1,0 +1,203 @@
+// Athens (fictional) seed data — Slice 19b.
+//
+// Mirrors the structure of seedData.ts but populated with content for
+// the fictional "Town of Athens, Virginia" used by the public demo
+// deployment (demo-hub.civic.social). Same civic issues as Floyd's
+// seed because the topics (waste disposal, surveillance cameras) are
+// nationally relevant — only the jurisdictional and governance
+// terminology change.
+//
+// Selected at runtime via CIVIC_SEED_FIXTURE=athens. Floyd remains
+// the default so production behavior is unchanged.
+
+import type { SeedScenario } from "./seedData.js";
+
+// --- Athens Green Box Dumpster Sites (active vote) ---
+
+export const ATHENS_GREEN_BOX: SeedScenario = {
+  process: {
+    id: "proc_greenbox_athens_001",
+    definition: { type: "civic.vote", version: "0.1" },
+    title: "Add More Secure Dumpster (Green Box) Sites",
+    description:
+      "Should the town of Athens invest in building additional fenced-in dumpster (green box) sites to improve access and reduce wildlife interference?",
+    createdBy: "user:civic-admin",
+    jurisdiction: "us-va-athens",
+    state: {
+      options: [
+        "Yes \u2014 build additional fenced-in dumpster sites in key areas",
+        "No \u2014 maintain current number and locations",
+        "Unsure / need more information",
+      ],
+      support_threshold: 3,
+      voting_duration_ms: 14 * 24 * 60 * 60 * 1000,
+      activation_mode: "direct",
+    },
+    content: {
+      core_question:
+        "Should the town of Athens invest in building additional fenced-in dumpster (green box) sites to improve access and reduce wildlife interference?",
+      sections: [
+        {
+          title: "Background",
+          body: [
+            "Athens residents rely on green box dumpster sites for waste disposal. In recent years, bears and other wildlife have increasingly accessed these dumpsters, creating mess, safety concerns, and additional maintenance costs.",
+            "The town has built a fenced-in dumpster facility on Main Street that has significantly reduced wildlife access and improved cleanliness. However, for many residents, this location is not convenient, requiring longer travel times for regular waste disposal.",
+            "Expanding secure, fenced-in dumpster sites across the town could improve accessibility while also addressing wildlife-related issues.",
+          ],
+        },
+        {
+          title: "Key considerations",
+          body: [
+            "Accessibility: Are current dumpster locations convenient for most residents?",
+            "Wildlife impact: Do fenced-in sites meaningfully reduce bear interference?",
+            "Cost: What is the cost of building and maintaining additional sites?",
+            "Land use: Where would new sites be located?",
+          ],
+        },
+        {
+          title: "Potential locations (examples)",
+          body: [
+            "North Athens",
+            "Near the historic district",
+            "Additional site on the south end of town",
+            "Near the town park entrance",
+          ],
+        },
+        {
+          title: "What your vote means",
+          body: [
+            "This vote provides a community signal to town officials about whether residents support expanding secure dumpster infrastructure.",
+            "Results are advisory but intended to reflect the preferences of participating Athens residents.",
+          ],
+        },
+      ],
+      key_tradeoff:
+        "Improved access and wildlife management vs. cost of new infrastructure",
+      links: [],
+      community_input: {
+        prompt:
+          "Do you have suggestions for locations, concerns, or alternatives?",
+        label:
+          "Optional: Share your thoughts (does not affect vote results)",
+      },
+      after_vote: {
+        body: "This vote is advisory and does not directly determine policy. The goal is to provide a clear signal of community sentiment to town officials.",
+        recipients: ["Athens Town Council"],
+      },
+    },
+  },
+  actions: [
+    { type: "process.activate", actor: "user:civic-admin", payload: {} },
+  ],
+  inputs: [],
+};
+
+// --- Athens Flock Camera Issue (gathering-support proposal) ---
+
+export const ATHENS_FLOCK_CAMERA: SeedScenario = {
+  process: {
+    id: "proc_flockcam_athens_001",
+    definition: { type: "civic.vote", version: "0.1" },
+    title: "Athens Flock Camera Use",
+    description:
+      "Should the town of Athens continue using Flock Safety license plate reader cameras?",
+    createdBy: "user:civic-admin",
+    jurisdiction: "us-va-athens",
+    state: {
+      options: [
+        "Yes \u2014 continue using the cameras",
+        "No \u2014 remove the cameras",
+      ],
+      support_threshold: 5,
+      voting_duration_ms: 7 * 24 * 60 * 60 * 1000,
+      activation_mode: "proposal_required",
+    },
+    content: {
+      core_question:
+        "Should the town of Athens continue using Flock Safety license plate reader cameras?",
+      sections: [
+        {
+          title: "What are Flock cameras?",
+          body: [
+            "Flock Safety cameras are automated license plate readers (ALPRs) used by law enforcement to:",
+            "Capture images of license plates",
+            "Compare plates against databases (e.g. stolen vehicles, warrants)",
+            "Assist in investigations",
+            "They do not continuously record video, but they do capture license plate numbers, timestamps, and location data.",
+          ],
+        },
+        {
+          title: "Why are they used?",
+          body: [
+            "Supporters argue they:",
+            "Help solve crimes (especially stolen vehicles)",
+            "Provide useful investigative leads",
+            "Extend law enforcement capabilities without constant patrol presence",
+          ],
+        },
+        {
+          title: "Concerns raised",
+          body: [
+            "Critics argue they:",
+            "Create a form of ongoing surveillance",
+            "Collect data on residents who are not suspected of wrongdoing",
+            "May lack sufficient transparency or oversight",
+            "Raise privacy and civil liberties concerns",
+          ],
+        },
+        {
+          title: "Local context",
+          body: [
+            "Flock cameras are typically deployed in coordination with local law enforcement.",
+            "In Athens, their continued use would likely depend on decisions made by the Athens Police Department and the Town Council.",
+            "This vote is intended to understand community sentiment and does not directly determine policy.",
+          ],
+        },
+      ],
+      key_tradeoff: "Public safety vs. privacy",
+      links: [
+        {
+          label: "Flock Safety website",
+          url: "https://www.flocksafety.com/",
+        },
+        {
+          label: "ACLU: Automated License Plate Readers",
+          url: "https://www.aclu.org/issues/privacy-technology/location-tracking/automated-license-plate-readers-alprs",
+        },
+        {
+          label: "EFF: ALPR overview",
+          url: "https://www.eff.org/pages/automated-license-plate-readers-alpr",
+        },
+      ],
+      community_input: {
+        prompt: "What concerns you most about this issue?",
+        label:
+          "Optional: Share your perspective (does not affect vote results)",
+      },
+      after_vote: {
+        body: "The goal is to provide a clear signal of community sentiment between elections. This vote is advisory and does not directly determine policy.",
+        recipients: ["Athens Town Council", "Athens Police Department"],
+      },
+    },
+  },
+  actions: [
+    { type: "process.propose", actor: "user:civic-admin", payload: {} },
+    { type: "process.support", actor: "user:athens-resident-1", payload: {} },
+    { type: "process.support", actor: "user:athens-resident-2", payload: {} },
+    { type: "process.support", actor: "user:athens-resident-3", payload: {} },
+  ],
+  inputs: [
+    {
+      author_id: "user:athens-resident-1",
+      body: "I'm worried about the data retention policies. How long are plate images stored, and who has access?",
+    },
+    {
+      author_id: "user:athens-resident-4",
+      body: "These cameras helped recover my neighbor's stolen truck last year. They work.",
+    },
+    {
+      author_id: "user:athens-resident-2",
+      body: "I don't think most people even know these exist. We need more transparency before making a decision.",
+    },
+  ],
+};

--- a/ui/.env
+++ b/ui/.env
@@ -41,3 +41,14 @@ VITE_HUB_PAGE_TITLE=Floyd County, VA — Civic Hub
 
 # Meta description and og:description.
 VITE_HUB_DESCRIPTION=Vote on local issues and see where our community stands. Floyd County, Virginia Civic Hub.
+
+# Slice 19a — governance terminology. Long form (delivered-to text,
+# admin pages) and short form (pill labels and filter labels).
+VITE_HUB_GOVERNING_BODY_NAME=Board of Supervisors
+VITE_HUB_GOVERNING_BODY_SHORT=BOS
+
+# Welcome-popup body shown to first-time visitors (IntroPopup).
+VITE_HUB_INTRO_BODY=This is where Floyd County residents weigh in on local issues, read Board of Supervisors meeting summaries, and stay in the loop between elections.
+
+# AuthModal residency-step intro copy (single sentence).
+VITE_HUB_RESIDENCY_INTRO=To participate in Floyd County civic processes, please confirm your residency and review the policies below.

--- a/ui/.env.example
+++ b/ui/.env.example
@@ -36,3 +36,20 @@ VITE_HUB_BANNER_URL=/floyd-banner.jpg
 VITE_HUB_BANNER_ALT=Downtown Floyd, Virginia — the Floyd Civic Hub
 VITE_HUB_PAGE_TITLE=Floyd County, VA — Civic Hub
 VITE_HUB_DESCRIPTION=Vote on local issues and see where our community stands. Floyd County, Virginia Civic Hub.
+
+# Slice 19a — governance terminology (long + short form).
+# Examples per jurisdiction:
+#   Floyd County: "Board of Supervisors" / "BOS"
+#   Town of Athens: "Town Council" / "Town Council"  (or "TC" if short matters)
+#   City of X: "City Council" / "City Council"
+VITE_HUB_GOVERNING_BODY_NAME=Board of Supervisors
+VITE_HUB_GOVERNING_BODY_SHORT=BOS
+
+# IntroPopup body — full freeform paragraph for the welcome popup.
+# Reference the jurisdiction and the governance body explicitly so
+# new visitors immediately understand what the hub is for.
+VITE_HUB_INTRO_BODY=This is where Floyd County residents weigh in on local issues, read Board of Supervisors meeting summaries, and stay in the loop between elections.
+
+# AuthModal residency-step intro — one sentence shown above the
+# residency-confirmation checkbox.
+VITE_HUB_RESIDENCY_INTRO=To participate in Floyd County civic processes, please confirm your residency and review the policies below.

--- a/ui/src/components/AuthModal.tsx
+++ b/ui/src/components/AuthModal.tsx
@@ -302,10 +302,7 @@ export default function AuthModal({ onComplete, onDismiss }: Props) {
         {step === "residency" && (
           <form onSubmit={handleResidency}>
             <h2 className="auth-title">One last thing</h2>
-            <p className="auth-description">
-              To participate in Floyd County civic processes, please confirm
-              your residency and review the policies below.
-            </p>
+            <p className="auth-description">{hub.residency_intro}</p>
 
             <label className="auth-checkbox-label auth-legal-checkbox">
               <input

--- a/ui/src/components/FeedFilter.tsx
+++ b/ui/src/components/FeedFilter.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import { useSearchParams } from "react-router-dom";
+import hub from "../config/hub";
 import "./FeedFilter.css";
 
 /**
@@ -44,7 +45,7 @@ const CHOICES: FeedFilterChoice[] = [
   },
   {
     key: "meeting_summary",
-    label: "BOS meeting summaries",
+    label: `${hub.governing_body_short} meeting summaries`,
     pillClass: "feed-filter-pill--meeting",
   },
 ];

--- a/ui/src/components/FeedPost.tsx
+++ b/ui/src/components/FeedPost.tsx
@@ -1,6 +1,7 @@
 import { Link } from "react-router-dom";
 import type { CivicEvent } from "../services/api";
 import { useIsWideViewport } from "../hooks/useIsWideViewport";
+import hub from "../config/hub";
 
 /**
  * Color/label kinds for the per-post type pill. Each maps to a token in
@@ -224,7 +225,7 @@ export function eventToPost(
         return {
           id: event.id,
           title,
-          pillLabel: "BOS meeting summary",
+          pillLabel: `${hub.governing_body_short} meeting summary`,
           pillKind: "meeting",
           summary,
           timestamp: event.timestamp,
@@ -250,7 +251,7 @@ export function eventToPost(
         // showed up when both lines said "N residents voted".
         const summary = data.headline_result
           ? String(data.headline_result)
-          : "Delivered to the Board of Supervisors.";
+          : `Delivered to the ${hub.governing_body_name}.`;
         return {
           id: event.id,
           title,

--- a/ui/src/components/IntroPopup.tsx
+++ b/ui/src/components/IntroPopup.tsx
@@ -86,11 +86,7 @@ export default function IntroPopup({ onDismiss }: Props) {
           Welcome to the {hub.name}.
         </h2>
 
-        <p className="intro-popup-text">
-          This is where Floyd County residents weigh in on local issues, read
-          Board of Supervisors meeting summaries, and stay in the loop between
-          elections.
-        </p>
+        <p className="intro-popup-text">{hub.intro_body}</p>
 
         <div className="intro-popup-actions">
           <button

--- a/ui/src/config/hub.ts
+++ b/ui/src/config/hub.ts
@@ -57,6 +57,32 @@ const hub = {
   banner_alt:
     import.meta.env.VITE_HUB_BANNER_ALT ??
     "Downtown Floyd, Virginia — the Floyd Civic Hub",
+  /**
+   * Slice 19a — governance terminology. Per-jurisdiction copy for
+   * the elected body that votes are delivered to and whose meetings
+   * get summarized. Floyd's BoS is "Board of Supervisors"; a town
+   * demo's might be "Town Council"; a city might be "City Council."
+   *
+   * `governing_body_name` is the long form (delivered-to text, admin
+   * pages); `governing_body_short` is the abbreviation used in pills
+   * and filter labels where width matters.
+   */
+  governing_body_name:
+    import.meta.env.VITE_HUB_GOVERNING_BODY_NAME ??
+    "Board of Supervisors",
+  governing_body_short:
+    import.meta.env.VITE_HUB_GOVERNING_BODY_SHORT ?? "BOS",
+  /**
+   * Welcome-popup body and AuthModal residency-intro copy. These are
+   * jurisdiction-specific freeform strings that don't generalize via
+   * a templating placeholder, so they're full-body env-overridable.
+   */
+  intro_body:
+    import.meta.env.VITE_HUB_INTRO_BODY ??
+    "This is where Floyd County residents weigh in on local issues, read Board of Supervisors meeting summaries, and stay in the loop between elections.",
+  residency_intro:
+    import.meta.env.VITE_HUB_RESIDENCY_INTRO ??
+    "To participate in Floyd County civic processes, please confirm your residency and review the policies below.",
 };
 
 export default hub;

--- a/ui/src/pages/AdminMeetingSummaries.tsx
+++ b/ui/src/pages/AdminMeetingSummaries.tsx
@@ -11,6 +11,7 @@ import {
   type SummaryBlock,
 } from "../services/api";
 import AdminTabs from "../components/AdminTabs";
+import hub from "../config/hub";
 import "./AdminMeetingSummaries.css";
 
 const STATUS_FILTERS: Array<{
@@ -271,7 +272,7 @@ export default function AdminMeetingSummaries() {
               value={meetingTitle}
               onChange={(e) => setMeetingTitle(e.target.value)}
               disabled={!isPending}
-              placeholder="Board of Supervisors Regular Meeting"
+              placeholder={`${hub.governing_body_name} Regular Meeting`}
             />
           </section>
 
@@ -502,8 +503,8 @@ export default function AdminMeetingSummaries() {
       <div className="admin-meeting-summaries-body">
         <h1>Meeting summaries</h1>
         <p className="admin-subtitle">
-          AI-generated summaries of Board of Supervisors meetings. Review
-          topic blocks and approve to publish to the public feed.
+          AI-generated summaries of {hub.governing_body_name} meetings.
+          Review topic blocks and approve to publish to the public feed.
         </p>
 
         <div className="admin-brief-filters">

--- a/ui/src/pages/AdminVoteResults.tsx
+++ b/ui/src/pages/AdminVoteResults.tsx
@@ -11,6 +11,7 @@ import {
 } from "../services/api";
 import AdminTabs from "../components/AdminTabs";
 import PostImagePicker from "../components/PostImagePicker";
+import hub from "../config/hub";
 import "./AdminVoteResults.css";
 
 const STATUS_FILTERS: Array<{
@@ -344,7 +345,7 @@ export default function AdminVoteResults() {
         <h1>Vote results</h1>
         <p className="admin-subtitle">
           Review and approve vote results. Approval delivers the results to the
-          Board of Supervisors and publishes them to the public feed.
+          {" "}{hub.governing_body_name} and publishes them to the public feed.
         </p>
 
         <div className="admin-brief-filters">

--- a/ui/src/pages/Propose.tsx
+++ b/ui/src/pages/Propose.tsx
@@ -4,6 +4,7 @@ import { submitProposal } from "../services/api";
 import { useAuth } from "../context/AuthContext";
 import { useRequireAuth } from "../hooks/useRequireAuth";
 import AuthModal from "../components/AuthModal";
+import hub from "../config/hub";
 
 export default function Propose() {
   const navigate = useNavigate();
@@ -63,7 +64,7 @@ export default function Propose() {
       <p className="propose-description">
         Submit an idea for the community to consider. With enough
         citizen support — your neighbors endorsing it — your suggestion
-        is reviewed and may become an official Floyd County advisory
+        is reviewed and may become an official {hub.jurisdiction} advisory
         vote.
       </p>
 

--- a/ui/src/pages/VoteResults.tsx
+++ b/ui/src/pages/VoteResults.tsx
@@ -4,6 +4,7 @@ import { getPublicVoteResults, type PublicVoteResults } from "../services/api";
 import { relativeTime, absoluteTime } from "../components/FeedPost";
 import PostFeaturedImage from "../components/PostFeaturedImage";
 import LinkPreviewCard from "../components/LinkPreviewCard";
+import hub from "../config/hub";
 import "./VoteResults.css";
 
 const URL_RE = /\bhttps?:\/\/\S+/gi;
@@ -86,9 +87,9 @@ export default function VoteResultsPage() {
         month: "long",
         day: "numeric",
       });
-      return `Delivered to the Board of Supervisors on ${dateLabel}.`;
+      return `Delivered to the ${hub.governing_body_name} on ${dateLabel}.`;
     }
-    return "Delivered to the Board of Supervisors.";
+    return `Delivered to the ${hub.governing_body_name}.`;
   })();
 
   return (


### PR DESCRIPTION
## Summary
- **19a:** new `VITE_HUB_GOVERNING_BODY_NAME` / `_SHORT` / `_INTRO_BODY` / `_RESIDENCY_INTRO` env vars with Floyd defaults baked in. All "BOS / Board of Supervisors / Floyd County residents…" copy across IntroPopup, AuthModal, FeedPost, FeedFilter, VoteResults, AdminMeetingSummaries, AdminVoteResults, and Propose now sources from `hub.*`.
- **19b:** new `seedDataAthens.ts` with the same two civic issues (green-box dumpsters, Flock cameras) rebranded for the fictional Town of Athens, VA. New `CIVIC_SEED_FIXTURE` backend env var selects between fixtures (default `floyd`).

## Risk profile
Floyd production unchanged: every governance ref defaults to its current Floyd value, the seed fixture selector defaults to Floyd, and the committed `ui/.env` carries Floyd defaults.

## Verified on preview
- Incognito IntroPopup: "Floyd County residents weigh in on local issues…" rendered identically to current production
- Filter pill: "BOS meeting summaries" unchanged
- Feed post pills: "Floyd County Gov" / "Vote open" / etc. unchanged
- Backend `npm run build` clean
- UI `npm run build` clean

## Test plan
- [x] UI build clean
- [x] Backend build clean
- [x] Floyd defaults render correctly in preview
- [ ] Post-merge: floyd.civic.social rebuilds with no visible change

## Follow-ups (not in this PR)
- Athens announcement seed scenarios (announcement creation flow doesn't fit current `runScenario`)
- Athens Town Council meeting summary seed scenarios (same reason)
- Set `VITE_HUB_INTRO_BODY`, `VITE_HUB_RESIDENCY_INTRO`, `VITE_HUB_GOVERNING_BODY_*` overrides on the demo Vercel project
- Set `CIVIC_SEED_FIXTURE=athens` on the demo + wipe demo Supabase to trigger reseed

🤖 Generated with [Claude Code](https://claude.com/claude-code)