### PR TITLE
Slice 19d: Athens announcements + Town Council meeting summaries in seed

### DIFF
--- a/src/controllers/debugController.ts
+++ b/src/controllers/debugController.ts
@@ -50,7 +50,7 @@ async function runScenario(
 ): Promise<Record<string, unknown>> {
   const process = await createProcess(scenario.process);
 
-  for (const action of scenario.actions) {
+  for (const action of scenario.actions ?? []) {
     await executeAction(process.id, action);
   }
 

--- a/src/debug/autoSeed.ts
+++ b/src/debug/autoSeed.ts
@@ -11,19 +11,34 @@
 import {
   createProcess,
   executeAction,
+  saveProcessState,
 } from "../services/processService.js";
 import { submitInput } from "../modules/civic.input/index.js";
 import { emitEvent } from "../events/eventEmitter.js";
 import { getEventCount } from "../events/eventStore.js";
 import { getDb } from "../db/client.js";
 import {
+  emitPublicationEvents as emitAnnouncementPublicationEvents,
+  type AnnouncementProcessContext,
+  type AnnouncementProcessState,
+} from "../modules/civic.announcement/index.js";
+import {
+  approveMeetingSummary,
+  emitCreationEvents as emitMeetingSummaryCreationEvents,
+  type MeetingSummaryProcessContext,
+  type MeetingSummaryProcessState,
+} from "../modules/civic.meeting_summary/index.js";
+import type { Process } from "../models/process.js";
+import {
   FLOYD_FLOCK_CAMERA,
   FLOYD_GREEN_BOX,
   type SeedScenario,
 } from "./seedData.js";
 import {
+  ATHENS_ANNOUNCEMENTS,
   ATHENS_FLOCK_CAMERA,
   ATHENS_GREEN_BOX,
+  ATHENS_MEETING_SUMMARIES,
 } from "./seedDataAthens.js";
 
 function allowSeed(): boolean {
@@ -44,7 +59,17 @@ function selectScenarios(): SeedScenario[] {
   const fixture = process.env.CIVIC_SEED_FIXTURE?.trim().toLowerCase();
   switch (fixture) {
     case "athens":
-      return [ATHENS_GREEN_BOX, ATHENS_FLOCK_CAMERA];
+      // Order matters for visual freshness in the feed (events sort
+      // descending by timestamp): we seed votes first, then
+      // announcements, then meeting summaries — so the feed shows the
+      // ballot-driving content above the news-style content above the
+      // longer-form summaries.
+      return [
+        ATHENS_GREEN_BOX,
+        ATHENS_FLOCK_CAMERA,
+        ...ATHENS_ANNOUNCEMENTS,
+        ...ATHENS_MEETING_SUMMARIES,
+      ];
     case "floyd":
     case undefined:
     case "":
@@ -60,23 +85,86 @@ function selectScenarios(): SeedScenario[] {
 async function runScenario(scenario: SeedScenario): Promise<void> {
   const proc = await createProcess(scenario.process);
 
-  for (const action of scenario.actions) {
-    await executeAction(proc.id, action);
-  }
+  // Slice 19b follow-up — type-aware dispatch. The vote/proposal
+  // path uses the generic action dispatcher; announcements and
+  // meeting summaries publish via type-specific event helpers
+  // because their lifecycles bypass the standard action flow.
+  // Adding a new process type here is a one-branch change.
+  const type = proc.definition.type;
 
-  if (scenario.inputs) {
-    for (const input of scenario.inputs) {
-      await submitInput(proc.id, input.author_id, input.body, {
-        hub_id: proc.hubId,
-        jurisdiction: proc.jurisdiction,
-        emit: emitEvent,
-      });
+  if (type === "civic.announcement") {
+    await runAnnouncementSeed(proc, scenario.process.createdBy);
+  } else if (type === "civic.meeting_summary") {
+    await runMeetingSummarySeed(proc, scenario.process.createdBy);
+  } else {
+    // civic.vote / civic.proposal — generic actions + community inputs.
+    for (const action of scenario.actions ?? []) {
+      await executeAction(proc.id, action);
+    }
+    if (scenario.inputs) {
+      for (const input of scenario.inputs) {
+        await submitInput(proc.id, input.author_id, input.body, {
+          hub_id: proc.hubId,
+          jurisdiction: proc.jurisdiction,
+          emit: emitEvent,
+        });
+      }
     }
   }
 
   console.log(
     `[auto-seed] Loaded: "${proc.title}" (${proc.id}) — status: ${proc.status}`,
   );
+}
+
+/**
+ * Mirror the announcement controller's create+publish flow:
+ * createProcess() already auto-emitted civic.process.created via
+ * processService; we then fire the module's publication events
+ * (which include another `created` with announcement-specific data
+ * plus result_published) and finalize the process row.
+ */
+async function runAnnouncementSeed(
+  proc: Process,
+  actor: string,
+): Promise<void> {
+  const state = proc.state as unknown as AnnouncementProcessState;
+  const ctx: AnnouncementProcessContext = {
+    process_id: proc.id,
+    hub_id: proc.hubId,
+    jurisdiction: proc.jurisdiction,
+    emit: emitEvent,
+  };
+  await emitAnnouncementPublicationEvents(ctx, actor, state);
+  proc.status = "finalized";
+  await saveProcessState(proc);
+}
+
+/**
+ * Mirror the meeting-summary cron + admin-approve flow:
+ * createProcess() already auto-emitted civic.process.created;
+ * emitCreationEvents fires aggregation_completed; approveMeetingSummary
+ * walks the state machine pending → approved → published and emits
+ * outcome_recorded + result_published. Finally we finalize the row.
+ *
+ * Demo seed data is published immediately (not pending review) so
+ * visitors see it in the feed without an admin step.
+ */
+async function runMeetingSummarySeed(
+  proc: Process,
+  actor: string,
+): Promise<void> {
+  const state = proc.state as unknown as MeetingSummaryProcessState;
+  const ctx: MeetingSummaryProcessContext = {
+    process_id: proc.id,
+    hub_id: proc.hubId,
+    jurisdiction: proc.jurisdiction,
+    emit: emitEvent,
+  };
+  await emitMeetingSummaryCreationEvents(ctx, actor, state);
+  await approveMeetingSummary(state, actor, ctx);
+  proc.status = "finalized";
+  await saveProcessState(proc);
 }
 
 // Memoize the seed run so concurrent requests don't trigger duplicate seeding.

--- a/src/debug/seedData.ts
+++ b/src/debug/seedData.ts
@@ -12,7 +12,13 @@ export interface SeedScenario {
     state: Record<string, unknown>;
     content?: Record<string, unknown>;
   };
-  actions: { type: string; actor: string; payload: Record<string, unknown> }[];
+  /**
+   * Generic process actions — used by civic.vote and civic.proposal
+   * scenarios that go through the standard action dispatcher.
+   * Optional: announcement and meeting-summary scenarios bypass
+   * action dispatch entirely (see autoSeed.ts type-aware runScenario).
+   */
+  actions?: { type: string; actor: string; payload: Record<string, unknown> }[];
   inputs?: { author_id: string; body: string }[];
 }
 

--- a/src/debug/seedDataAthens.ts
+++ b/src/debug/seedDataAthens.ts
@@ -1,11 +1,12 @@
-// Athens (fictional) seed data — Slice 19b.
+// Athens (fictional) seed data — Slice 19b + follow-up.
 //
 // Mirrors the structure of seedData.ts but populated with content for
 // the fictional "Town of Athens, Virginia" used by the public demo
 // deployment (demo-hub.civic.social). Same civic issues as Floyd's
-// seed because the topics (waste disposal, surveillance cameras) are
-// nationally relevant — only the jurisdictional and governance
-// terminology change.
+// seed for the votes (waste disposal, surveillance cameras — these
+// topics are nationally relevant); fully synthetic announcements
+// and Town Council meeting summaries flesh out the rest of the feed
+// so the demo looks lived-in rather than half-populated.
 //
 // Selected at runtime via CIVIC_SEED_FIXTURE=athens. Floyd remains
 // the default so production behavior is unchanged.
@@ -201,3 +202,311 @@ export const ATHENS_FLOCK_CAMERA: SeedScenario = {
     },
   ],
 };
+
+// --- Athens announcements ---
+//
+// Synthetic news-style posts authored as if published directly by
+// the Town of Athens government. The seed runner publishes these
+// via the announcement module's emitPublicationEvents flow; they
+// appear in the feed as standard announcement cards.
+//
+// Author role "Town of Athens Government" gets abbreviated to
+// "Town of Athens Gov" in the pill (per Slice 17.1's
+// abbreviateGovernment helper).
+
+const ATHENS_ANNOUNCEMENT_AUTHOR = "user:athens-admin";
+const ATHENS_ANNOUNCEMENT_AUTHOR_ROLE = "Town of Athens Government";
+
+const ATHENS_TOWN_COUNCIL_NEXT_MEETING: SeedScenario = {
+  process: {
+    id: "proc_athens_announce_council_meeting",
+    definition: { type: "civic.announcement", version: "0.1" },
+    title: "Town Council Meeting — Thursday May 7",
+    description:
+      "The next regular Town Council meeting is Thursday, May 7 at 7:00 PM in the Town Hall meeting room.",
+    createdBy: ATHENS_ANNOUNCEMENT_AUTHOR,
+    jurisdiction: "us-va-athens",
+    state: {
+      title: "Town Council Meeting — Thursday May 7",
+      body: "The next regular Town Council meeting is **Thursday, May 7 at 7:00 PM** in the Town Hall meeting room (200 Main Street). The published agenda includes a vote on the FY26 budget draft, an update on the downtown sidewalk replacement project, and public comment.\n\nMeetings are open to the public. Recordings and minutes are posted to the hub within a week of each meeting.",
+      author_id: ATHENS_ANNOUNCEMENT_AUTHOR,
+      author_role: ATHENS_ANNOUNCEMENT_AUTHOR_ROLE,
+      links: [],
+      image_url: null,
+      image_alt: null,
+    },
+  },
+};
+
+const ATHENS_WATER_MAIN_FLUSH: SeedScenario = {
+  process: {
+    id: "proc_athens_announce_water_main",
+    definition: { type: "civic.announcement", version: "0.1" },
+    title: "Water Main Flushing — May 3 to May 5",
+    description:
+      "Crews will flush water mains across the south side of town from Saturday May 3 through Monday May 5. Discolored water is harmless but residents may want to wait before doing laundry.",
+    createdBy: ATHENS_ANNOUNCEMENT_AUTHOR,
+    jurisdiction: "us-va-athens",
+    state: {
+      title: "Water Main Flushing — May 3 to May 5",
+      body: "Public works crews will flush water mains across the south side of town from **Saturday, May 3 through Monday, May 5**, between 8 AM and 4 PM each day.\n\nResidents on Maple, Oak, Cedar, and Pine streets may notice temporarily discolored water. The water is safe to drink, but you may want to wait until evening before running laundry. If discoloration persists past 24 hours after flushing ends, please call the Town Public Works office at 555-0100.",
+      author_id: ATHENS_ANNOUNCEMENT_AUTHOR,
+      author_role: ATHENS_ANNOUNCEMENT_AUTHOR_ROLE,
+      links: [],
+      image_url: null,
+      image_alt: null,
+    },
+  },
+};
+
+const ATHENS_SPRING_FESTIVAL: SeedScenario = {
+  process: {
+    id: "proc_athens_announce_spring_festival",
+    definition: { type: "civic.announcement", version: "0.1" },
+    title: "Athens Spring Festival — Saturday May 17",
+    description:
+      "The annual Athens Spring Festival returns to the town square on Saturday, May 17 from 10 AM to 6 PM. Live music, food vendors, kids' activities, and a 5K fun run.",
+    createdBy: ATHENS_ANNOUNCEMENT_AUTHOR,
+    jurisdiction: "us-va-athens",
+    state: {
+      title: "Athens Spring Festival — Saturday May 17",
+      body: "The annual Athens Spring Festival returns to the town square on **Saturday, May 17 from 10 AM to 6 PM**.\n\nFeaturing live music on the gazebo stage, local food vendors, kids' activities, and the morning 5K fun run kicking off at 8 AM. Main Street will be closed to traffic between Oak and Cedar from 7 AM to 7 PM; please use the Maple Street detour.\n\nVendor applications are still open through May 9 — contact the Town Manager's office at townmgr@athens-va.example to apply.",
+      author_id: ATHENS_ANNOUNCEMENT_AUTHOR,
+      author_role: ATHENS_ANNOUNCEMENT_AUTHOR_ROLE,
+      links: [],
+      image_url: null,
+      image_alt: null,
+    },
+  },
+};
+
+const ATHENS_PARK_BENCHES_SURVEY: SeedScenario = {
+  process: {
+    id: "proc_athens_announce_park_benches",
+    definition: { type: "civic.announcement", version: "0.1" },
+    title: "Park Benches Survey — Help Us Choose New Locations",
+    description:
+      "The Town is replacing eight worn park benches and adding four new ones. We want your input on where they should go.",
+    createdBy: ATHENS_ANNOUNCEMENT_AUTHOR,
+    jurisdiction: "us-va-athens",
+    state: {
+      title: "Park Benches Survey — Help Us Choose New Locations",
+      body: "The Town received a small grant to replace eight worn park benches and add four entirely new ones across our public spaces. Before placing them, we want resident input on where they'd be most useful.\n\nThe survey takes about three minutes and asks where you'd most appreciate a place to sit when walking through town — along the Main Street corridor, near the playground, on the trail behind the library, etc.\n\nPaper copies are available at the Town Hall front desk for residents who prefer them. Survey closes Friday, May 23.",
+      author_id: ATHENS_ANNOUNCEMENT_AUTHOR,
+      author_role: ATHENS_ANNOUNCEMENT_AUTHOR_ROLE,
+      links: [],
+      image_url: null,
+      image_alt: null,
+    },
+  },
+};
+
+const ATHENS_DOWNTOWN_SIDEWALK_PROJECT: SeedScenario = {
+  process: {
+    id: "proc_athens_announce_sidewalk",
+    definition: { type: "civic.announcement", version: "0.1" },
+    title: "Downtown Sidewalk Replacement Begins May 12",
+    description:
+      "Sidewalks along Main Street between Oak and Pine will be replaced over six weeks starting May 12. Pedestrian access will remain on at least one side of the street throughout.",
+    createdBy: ATHENS_ANNOUNCEMENT_AUTHOR,
+    jurisdiction: "us-va-athens",
+    state: {
+      title: "Downtown Sidewalk Replacement Begins May 12",
+      body: "The downtown sidewalk replacement project begins **Monday, May 12** and is expected to take six weeks. Crews will work in three phases:\n\n1. Main Street between Oak and Maple (May 12 – May 23)\n2. Main Street between Maple and Cedar (May 26 – June 6)\n3. Main Street between Cedar and Pine (June 9 – June 20)\n\nPedestrian access will remain on at least one side of the street throughout. On-street parking will be reduced during active work hours; please use the public lot behind Town Hall.\n\nQuestions about access for downtown businesses can be directed to the Town Manager's office.",
+      author_id: ATHENS_ANNOUNCEMENT_AUTHOR,
+      author_role: ATHENS_ANNOUNCEMENT_AUTHOR_ROLE,
+      links: [],
+      image_url: null,
+      image_alt: null,
+    },
+  },
+};
+
+const ATHENS_RECYCLING_SCHEDULE: SeedScenario = {
+  process: {
+    id: "proc_athens_announce_recycling",
+    definition: { type: "civic.announcement", version: "0.1" },
+    title: "Recycling Pickup Schedule Change Starting June 1",
+    description:
+      "Curbside recycling will move from biweekly Wednesday pickups to weekly Monday pickups starting June 1. No additional fee.",
+    createdBy: ATHENS_ANNOUNCEMENT_AUTHOR,
+    jurisdiction: "us-va-athens",
+    state: {
+      title: "Recycling Pickup Schedule Change Starting June 1",
+      body: "Starting **Monday, June 1**, curbside recycling moves from **biweekly Wednesdays** to **weekly Mondays**. There is no additional fee — the change is part of our renegotiated contract with Mountain Valley Recycling.\n\nAccepted materials are unchanged: paper, cardboard, glass, aluminum cans, and plastics #1 and #2. Please rinse containers before placing them in the bin and do not bag recyclables in plastic.\n\nThe last biweekly Wednesday pickup is May 28. The first weekly Monday pickup is June 1.",
+      author_id: ATHENS_ANNOUNCEMENT_AUTHOR,
+      author_role: ATHENS_ANNOUNCEMENT_AUTHOR_ROLE,
+      links: [],
+      image_url: null,
+      image_alt: null,
+    },
+  },
+};
+
+export const ATHENS_ANNOUNCEMENTS: SeedScenario[] = [
+  ATHENS_TOWN_COUNCIL_NEXT_MEETING,
+  ATHENS_WATER_MAIN_FLUSH,
+  ATHENS_SPRING_FESTIVAL,
+  ATHENS_PARK_BENCHES_SURVEY,
+  ATHENS_DOWNTOWN_SIDEWALK_PROJECT,
+  ATHENS_RECYCLING_SCHEDULE,
+];
+
+// --- Athens Town Council meeting summaries ---
+//
+// Synthetic published meeting summaries representing recent Town
+// Council meetings. The seed runner walks each through
+// emitCreationEvents → approveMeetingSummary so they appear in the
+// feed as published summaries (no "pending review" admin step
+// required for demo content).
+//
+// Block structure mirrors what the meeting-summary AI pipeline
+// produces in production: 4–6 topic blocks per meeting, each with a
+// title and narrative summary. start_time_seconds is null for the
+// demo content (no real recording timestamps); action_taken is
+// optional and used to flag votes / motions.
+
+const ATHENS_COUNCIL_MEETING_APRIL_23: SeedScenario = {
+  process: {
+    id: "proc_athens_meeting_2026_04_23",
+    definition: { type: "civic.meeting_summary", version: "0.1" },
+    title: "Meeting summary: 2026-04-23",
+    description:
+      "Town Council Regular Meeting — April 23, 2026. Topics: FY26 budget draft, downtown sidewalk project award, recycling contract renewal, and resident comment on park improvements.",
+    createdBy: "user:athens-admin",
+    jurisdiction: "us-va-athens",
+    state: {
+      type: "civic.meeting_summary",
+      source_id: "athens-2026-04-23",
+      source_minutes_url:
+        "https://demo-hub.civic.social/seed-data/athens-2026-04-23-minutes.pdf",
+      source_video_url: null,
+      additional_video_urls: [],
+      meeting_title: "Town Council Regular Meeting",
+      meeting_date: "2026-04-23",
+      blocks: [
+        {
+          topic_title: "FY26 budget draft — first reading",
+          topic_summary:
+            "Town Manager Rivera presented the proposed FY26 operating budget. Total spending is up 3.4% over FY25, driven primarily by paving program expansion and a contracted 2% cost-of-living adjustment for town staff. The Council asked clarifying questions about line items for parks maintenance and the police department's vehicle replacement schedule. No vote was taken; the budget will return for second reading and a formal vote at the May 28 meeting following a public hearing on May 14.",
+          start_time_seconds: null,
+          action_taken: "First reading completed. Public hearing scheduled May 14.",
+        },
+        {
+          topic_title: "Downtown sidewalk project — contract award",
+          topic_summary:
+            "The Council reviewed three bids received for the Main Street sidewalk replacement project. The bid review committee recommended awarding to Blue Ridge Concrete (lowest qualifying bid at $186,400) over two higher bids. Construction is scheduled to begin May 12 and complete by late June. The contract includes a $10,000 contingency for unforeseen subgrade conditions.",
+          start_time_seconds: null,
+          action_taken:
+            "Motion to award contract to Blue Ridge Concrete passed 5–0.",
+        },
+        {
+          topic_title: "Recycling contract renewal",
+          topic_summary:
+            "Mountain Valley Recycling presented terms for a three-year contract renewal at the same per-household rate. The new contract shifts pickup from biweekly Wednesdays to weekly Mondays at no additional cost — Mountain Valley reports it improves their route efficiency. Some council members asked about the addition of plastics #5 to the accepted materials list; Mountain Valley said it would be feasible in year two if regional sorting capacity expands.",
+          start_time_seconds: null,
+          action_taken:
+            "Motion to authorize the Town Manager to sign the renewal passed 5–0.",
+        },
+        {
+          topic_title: "Public comment — park improvements",
+          topic_summary:
+            "Three residents spoke during public comment, all on the park benches survey announced last week. One asked whether the survey results would be public; Town Manager Rivera confirmed they would be summarized and published to the hub. A second asked the council to consider adding shade trees alongside the bench placements; the council asked staff to bring a follow-up cost estimate. A third spoke in support of the playground equipment refresh that's pending grant approval.",
+          start_time_seconds: null,
+          action_taken: null,
+        },
+        {
+          topic_title: "Adjournment",
+          topic_summary:
+            "Mayor Henley adjourned the meeting at 8:42 PM. Next regular meeting: Thursday, May 7 at 7:00 PM.",
+          start_time_seconds: null,
+          action_taken: null,
+        },
+      ],
+      approval_status: "pending",
+      generated_at: "2026-04-24T14:00:00Z",
+      approved_at: null,
+      published_at: null,
+      admin_notes: "",
+      last_edited_at: null,
+      edit_count: 0,
+      ai_instructions_used: "(demo seed — no AI generation)",
+      ai_model: "(demo seed — no AI generation)",
+      ai_attribution_label: "AI-generated summary",
+    },
+  },
+};
+
+const ATHENS_COUNCIL_BUDGET_WORKSHOP: SeedScenario = {
+  process: {
+    id: "proc_athens_meeting_2026_04_16",
+    definition: { type: "civic.meeting_summary", version: "0.1" },
+    title: "Meeting summary: 2026-04-16",
+    description:
+      "Town Council Budget Workshop — April 16, 2026. Department-by-department review of FY26 spending requests, with a focus on capital improvements and personnel costs.",
+    createdBy: "user:athens-admin",
+    jurisdiction: "us-va-athens",
+    state: {
+      type: "civic.meeting_summary",
+      source_id: "athens-2026-04-16",
+      source_minutes_url:
+        "https://demo-hub.civic.social/seed-data/athens-2026-04-16-minutes.pdf",
+      source_video_url: null,
+      additional_video_urls: [],
+      meeting_title: "Town Council Budget Workshop",
+      meeting_date: "2026-04-16",
+      blocks: [
+        {
+          topic_title: "Public Works — operating + capital",
+          topic_summary:
+            "Director Lee presented the Public Works request: $612,000 operating (flat from FY25) and $187,000 capital, the bulk of which is the downtown sidewalk replacement project. The Council asked about the timing of vehicle replacements; one of the dump trucks is at end-of-life but Lee proposed deferring until FY27 if a low-mileage replacement comes available at auction.",
+          start_time_seconds: null,
+          action_taken: null,
+        },
+        {
+          topic_title: "Police Department — operating",
+          topic_summary:
+            "Chief Morales presented a $740,000 request — a 4.1% increase over FY25, driven primarily by the negotiated COLA and one additional patrol vehicle (replacing a 2018 cruiser at 142,000 miles). The Council asked about the Flock Safety camera contract that's being separately discussed via the hub's resident vote; Chief Morales noted the police budget assumes the cameras continue, and would be revised if the resident vote signals otherwise.",
+          start_time_seconds: null,
+          action_taken: null,
+        },
+        {
+          topic_title: "Parks and Recreation — capital",
+          topic_summary:
+            "Recreation Coordinator Park presented the parks capital request: $42,000 for the bench replacements (announced separately for resident input on placement) and $115,000 in pending playground equipment, contingent on a state grant currently under review. The grant decision is expected by mid-May. If the grant is denied, the playground line drops to $25,000 for safety repairs only.",
+          start_time_seconds: null,
+          action_taken: null,
+        },
+        {
+          topic_title: "Library — operating",
+          topic_summary:
+            "Library Director Chen presented a $185,000 operating request, flat from FY25. Highlights: a renewed digital materials subscription bundle that doubled e-book circulation in FY25, and a small budget line for the summer reading program ($2,500). No capital requests this cycle.",
+          start_time_seconds: null,
+          action_taken: null,
+        },
+        {
+          topic_title: "Next steps",
+          topic_summary:
+            "Town Manager Rivera will compile department requests into a draft FY26 budget for first reading at the April 23 regular meeting. A formal public hearing is scheduled for May 14, with adoption targeted for the May 28 meeting.",
+          start_time_seconds: null,
+          action_taken: null,
+        },
+      ],
+      approval_status: "pending",
+      generated_at: "2026-04-17T10:00:00Z",
+      approved_at: null,
+      published_at: null,
+      admin_notes: "",
+      last_edited_at: null,
+      edit_count: 0,
+      ai_instructions_used: "(demo seed — no AI generation)",
+      ai_model: "(demo seed — no AI generation)",
+      ai_attribution_label: "AI-generated summary",
+    },
+  },
+};
+
+export const ATHENS_MEETING_SUMMARIES: SeedScenario[] = [
+  ATHENS_COUNCIL_MEETING_APRIL_23,
+  ATHENS_COUNCIL_BUDGET_WORKSHOP,
+];


### PR DESCRIPTION
## Summary
- Extends `runScenario()` in `autoSeed.ts` with type-aware dispatch: civic.announcement → `emitPublicationEvents` + finalize; civic.meeting_summary → `emitCreationEvents` → `approveMeetingSummary` → finalize. Vote/proposal path unchanged.
- Adds 6 Athens announcements and 2 Town Council meeting summaries to `seedDataAthens.ts`. Demo feed will show 10 items total (2 votes + 6 announcements + 2 meeting summaries) instead of 2 votes.
- `SeedScenario.actions` made optional (announcements + meeting summaries don't use it). `debugController.ts` updated for the new optional shape.

## Risk profile
Floyd untouched. New content gated behind `CIVIC_SEED_FIXTURE=athens`. The runScenario type-aware dispatch adds new branches but the existing vote/proposal path is unchanged.

## Test plan
- [x] Backend `npm run build` clean
- [ ] Post-merge + reseed: demo-hub.civic.social shows 10 seeded items across all four pill types

🤖 Generated with [Claude Code](https://claude.com/claude-code)